### PR TITLE
does not give any custom top margin on searchbox

### DIFF
--- a/src/scss/search-custom.scss
+++ b/src/scss/search-custom.scss
@@ -1,8 +1,5 @@
 @import 'node_modules/leaflet-geocoder-mapzen/dist/leaflet-geocoder-mapzen';
 
-.leaflet-pelias-control {
-  top: 50px;
-}
 /* Medium Devices, Desktops */
 @media only screen and (max-width : 992px) {
 


### PR DESCRIPTION
- Previous custom style on search box assumes that users put search box `lefttop` position. It makes problems such as #173 
- closes #173 