### PR TITLE
Test S3 failures to prevent clobbering

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,10 +10,6 @@ test:
     - npm run build
 
 deployment:
-  staging:
-    branch: 175-migurski-test-s3-clobbering
-    commands:
-      - ./deploy.sh static-dev.mapzen.com
   production:
     branch: master
     commands:

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,10 @@ test:
     - npm run build
 
 deployment:
+  staging:
+    branch: 175-migurski-test-s3-clobbering
+    commands:
+      - ./deploy.sh static-dev.mapzen.com
   production:
     branch: master
     commands:

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,7 @@ if aws s3 ls "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js"; then
     aws s3 cp --recursive --quiet "s3://static-prod.mapzen.com/js/${VPATCH}" "live-${VPATCH}"
 
     for NAME in mapzen.min.js mapzen.js mapzen.css images; do
-        if diff -r "dist/${NAME}" "live-${VPATCH}/${NAME}"; then
+        if diff -rq "dist/${NAME}" "live-${VPATCH}/${NAME}"; then
             echo "No differences between dist/${NAME} and live-${VPATCH}/${NAME}"
         else
             echo "Found a difference between dist/${NAME} and live-${VPATCH}/${NAME}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,8 @@ VPATCH=`cut -d. -f1,2,3 VERSION`
 VMINOR=`cut -d. -f1,2 VERSION`
 VMAJOR=`cut -d. -f1 VERSION`
 
+echo ' /* whatever */ ' >> dist/mapzen.css
+
 if aws s3 ls "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js"; then
     echo "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js already exits, checking diffs..."
     aws s3 cp --recursive --quiet "s3://static-prod.mapzen.com/js/${VPATCH}" "live-${VPATCH}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,8 +6,6 @@ VPATCH=`cut -d. -f1,2,3 VERSION`
 VMINOR=`cut -d. -f1,2 VERSION`
 VMAJOR=`cut -d. -f1 VERSION`
 
-echo ' /* whatever */ ' >> dist/mapzen.css
-
 if aws s3 ls "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js"; then
     echo "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js already exits, checking diffs..."
     aws s3 cp --recursive --quiet "s3://static-prod.mapzen.com/js/${VPATCH}" "live-${VPATCH}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,14 +7,14 @@ VMINOR=`cut -d. -f1,2 VERSION`
 VMAJOR=`cut -d. -f1 VERSION`
 
 if aws s3 ls "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js"; then
-    echo "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js already exits"
-    aws s3 cp --recursive "s3://static-prod.mapzen.com/js/${VPATCH}" "live-{$VPATCH}"
+    echo "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js already exits, checking diffs..."
+    aws s3 cp --recursive --quiet "s3://static-prod.mapzen.com/js/${VPATCH}" "live-${VPATCH}"
 
     for NAME in mapzen.min.js mapzen.js mapzen.css images; do
-        if diff -r "dist/${NAME}" "live-{$VPATCH}/${NAME}"; then
-            echo "No differences between dist/${NAME} and live-{$VPATCH}/${NAME}"
+        if diff -r "dist/${NAME}" "live-${VPATCH}/${NAME}"; then
+            echo "No differences between dist/${NAME} and live-${VPATCH}/${NAME}"
         else
-            echo "Found a difference between dist/${NAME} and live-{$VPATCH}/${NAME}"
+            echo "Found a difference between dist/${NAME} and live-${VPATCH}/${NAME}"
             exit 1
         fi
     done

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,16 @@ VMAJOR=`cut -d. -f1 VERSION`
 
 if aws s3 ls "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js"; then
     echo "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js already exits"
-    exit 1
+    aws s3 cp --recursive "s3://static-prod.mapzen.com/js/${VPATCH}" "live-{$VPATCH}"
+
+    for NAME in mapzen.min.js mapzen.js mapzen.css images; do
+        if diff -r "dist/${NAME}" "live-{$VPATCH}/${NAME}"; then
+            echo "No differences between dist/${NAME} and live-{$VPATCH}/${NAME}"
+        else
+            echo "Found a difference between dist/${NAME} and live-{$VPATCH}/${NAME}"
+            exit 1
+        fi
+    done
 fi
 
 for DIR in "js/${VPATCH}" "js/${VMINOR}" "js/${VMAJOR}" "js"; do

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,11 @@ VPATCH=`cut -d. -f1,2,3 VERSION`
 VMINOR=`cut -d. -f1,2 VERSION`
 VMAJOR=`cut -d. -f1 VERSION`
 
+if aws s3 ls "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js"; then
+    echo "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js already exits"
+    exit 1
+fi
+
 for DIR in "js/${VPATCH}" "js/${VMINOR}" "js/${VMAJOR}" "js"; do
     aws s3 cp dist/mapzen.min.js s3://${BUCKET}/${DIR}/mapzen.min.js
     aws s3 cp dist/mapzen.js s3://${BUCKET}/${DIR}/mapzen.js


### PR DESCRIPTION
Introduces an S3 check, so that deployment will fail if a previously-published version exists.

Part of #175.