### PR TITLE
Unifying attribution

### DIFF
--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -7,6 +7,13 @@ var MapControl = L.Map.extend({
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
+
+    // Adding Mapzen attribuition to Leaflet
+    if (this.attributionControl) {
+      this.attributionControl.setPrefix('');
+      this.attributionControl.addAttribution('Powered by <a href="https://mapzen.com">Mapzen</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors');
+      this.attributionControl.addAttribution('<a href="http://leafletjs.com/">Leaflet</a>');
+    }
     // Set Icon path manually
     L.Icon.Default.imagePath = this._getImagePath();
 
@@ -46,8 +53,7 @@ var MapControl = L.Map.extend({
       console.log('given scene:', this.options.scene);
       console.log('using scene:', (this.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
       Tangram.leafletLayer({
-        scene: (this.options.scene || L.Mapzen.HouseStyles.BubbleWrap),
-        attribution: '<a href="https://mapzen.com/tangram" target="_blank">Tangram</a> | &copy; OSM contributors | <a href="https://mapzen.com/" target="_blank">Mapzen</a>'
+        scene: (this.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
       }).addTo(this);
     } else {
       // When WebGL is not avilable

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -3,14 +3,16 @@ var L = require('leaflet');
 var tangram = require('./tangram');
 
 var MapControl = L.Map.extend({
-  options: {},
+  options: {
+    attributionText: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors'
+  },
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
-    // Adding Mapzen attribuition to Leaflet
+    // Adding Mapzen attribution to Leaflet
     if (this.attributionControl) {
       this.attributionControl.setPrefix('');
-      this.attributionControl.addAttribution('Powered by <a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data © <a href="https://openstreetmap.org/copyright">OSM</a>contributors');
+      this.attributionControl.addAttribution(this.options.attributionText);
       this.attributionControl.addAttribution('<a href="http://leafletjs.com/">Leaflet</a>');
     }
     // Set Icon path manually

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -7,11 +7,10 @@ var MapControl = L.Map.extend({
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
-
     // Adding Mapzen attribuition to Leaflet
     if (this.attributionControl) {
       this.attributionControl.setPrefix('');
-      this.attributionControl.addAttribution('Powered by <a href="https://mapzen.com">Mapzen</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors');
+      this.attributionControl.addAttribution('Powered by <a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data © <a href="https://openstreetmap.org/copyright">OSM</a>contributors');
       this.attributionControl.addAttribution('<a href="http://leafletjs.com/">Leaflet</a>');
     }
     // Set Icon path manually

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -23,7 +23,6 @@ var Geocoder = L.Control.extend({
 
   options: {
     position: 'topleft',
-    attribution: 'Geocoding by <a href="https://mapzen.com/projects/search/">Mapzen</a>',
     url: 'https://search.mapzen.com/v1',
     placeholder: 'Search',
     title: 'Search',
@@ -889,9 +888,6 @@ var Geocoder = L.Control.extend({
     L.DomEvent.on(this._map, 'touchstart', this._onMapInteraction, this);
 
     L.DomEvent.disableClickPropagation(this._container);
-    if (map.attributionControl) {
-      map.attributionControl.addAttribution(this.options.attribution);
-    }
     return container;
   },
 
@@ -929,10 +925,6 @@ var Geocoder = L.Control.extend({
       }
     }
     previousWidth = width;
-  },
-
-  onRemove: function (map) {
-    map.attributionControl.removeAttribution(this.options.attribution);
   }
 });
 


### PR DESCRIPTION
- this pr got rid of the parts from each component (Tangram, Search) writing their own attribution. 
- `mapControl` writes attribution when Map is initialized instead. 
