### PR TITLE
make Tangram singleton

### DIFF
--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -1,6 +1,6 @@
 'use strict';
 var L = require('leaflet');
-var tangram = require('./tangram');
+var TangramLayer = require('./tangram');
 
 var MapControl = L.Map.extend({
   options: {
@@ -8,7 +8,16 @@ var MapControl = L.Map.extend({
   },
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
+    // Inject Tangram script right away
+    // var tangramLayer = new TangramControl({
+    //   scene: this.options.scene
+    // });
+
+
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
+
+    var tangramLayer = TangramLayer.addTo(this, this.options);
+
     // Adding Mapzen attribution to Leaflet
     if (this.attributionControl) {
       this.attributionControl.setPrefix('');
@@ -24,11 +33,6 @@ var MapControl = L.Map.extend({
       this.setView(e.latlng, this.getZoom() + 1);
     });
     this._checkConditions(false);
-
-    // Set up scene when Tangram script is injected
-    // If there is already Tangram object available, just set up scene.
-    if (typeof Tangram === 'undefined') L.DomEvent.on(tangram.scriptEl, 'load', this._setupScene, this);
-    else this._setupScene();
   },
 
   _getImagePath: function () {
@@ -46,22 +50,6 @@ var MapControl = L.Map.extend({
         path = src.split(mapzenRe)[0];
         return (path ? path + '/' : '') + 'images';
       }
-    }
-  },
-
-  _setupScene: function () {
-    if (this._hasWebGL()) {
-      console.log('given scene:', this.options.scene);
-      console.log('using scene:', (this.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
-      Tangram.leafletLayer({
-        scene: (this.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
-      }).addTo(this);
-    } else {
-      // When WebGL is not avilable
-      console.log('WebGL is not available, falling back to OSM default tile.');
-      L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
-      }).addTo(this);
     }
   },
 
@@ -86,15 +74,6 @@ var MapControl = L.Map.extend({
     // need to add more check to detect touch device
     if ('ontouchstart' in window) {
       this._disableZoomControl();
-    }
-  },
-
-  _hasWebGL: function () {
-    try {
-      var canvas = document.createElement('canvas');
-      return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
-    } catch (x) {
-      return false;
     }
   },
 

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -4,15 +4,18 @@ var TangramLayer = require('./tangram');
 
 var MapControl = L.Map.extend({
   options: {
-    attributionText: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors'
+    attributionText: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors',
+    useTangram: true
   },
 
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
 
-    var tangramLayer = TangramLayer.init();
-    tangramLayer.addTo(this);
+    if (this.options.useTangram) {
+      var tangramLayer = TangramLayer.init();
+      tangramLayer.addTo(this);
+    }
 
     // Adding Mapzen attribution to Leaflet
     if (this.attributionControl) {

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -6,17 +6,13 @@ var MapControl = L.Map.extend({
   options: {
     attributionText: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors'
   },
+
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
-    // Inject Tangram script right away
-    // var tangramLayer = new TangramControl({
-    //   scene: this.options.scene
-    // });
-
-
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
 
-    var tangramLayer = TangramLayer.addTo(this, this.options);
+    var tangramLayer = TangramLayer.init();
+    tangramLayer.addTo(this);
 
     // Adding Mapzen attribution to Leaflet
     if (this.attributionControl) {

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -5,14 +5,14 @@ var TangramLayer = require('./tangram');
 var MapControl = L.Map.extend({
   options: {
     attributionText: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors',
-    useTangram: true
+    _useTangram: true
   },
 
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
 
-    if (this.options.useTangram) {
+    if (this.options._useTangram) {
       var tangramLayer = TangramLayer.init();
       tangramLayer.addTo(this);
     }

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -30,7 +30,6 @@ var TangramLayer = (function () {
         return window.setTimeout(this.addTo.bind(this, map), 100);
       } else {
         if (this._hasWebGL()) {
-          console.log(map);
           console.log('given scene:', map.options.scene);
           console.log('using scene:', (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
           Tangram.leafletLayer({

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -1,35 +1,90 @@
 // Tangram can't be bundled from source since it needs to be able to access a full copy of itself
 // (either as a URL or full string of all source code) in order to load itself into web workers
 // This script injects the Tangram with script tag, so that Tangram doesn't need to be included with outside tag
+var L = require('leaflet');
+var TangramLayer = (function () {
 
-var TangramScript = (function () {
-  var tangramScriptURL = 'https://mapzen.com/tangram/0.8/tangram.min.js';
-  var oScript;
+  var tangramLayerInstance;
 
-  var loadError = function (oError) {
-    console.log(oError);
-    throw new URIError('The script ' + oError.target.src + ' is not accessible.');
+  var tangramLayer = {
+
+    init: function(_map, _options) {
+
+      this.map = _map;
+      this.options = _options;
+      // Start importing script as soon as Mapzen.js started
+      // When there is no Tangram object available.
+      if (typeof Tangram === 'undefined') {
+        var tangramScriptURL = 'https://mapzen.com/tangram/0.8/tangram.min.js';
+        this._importScript(tangramScriptURL);
+      } else {
+        // Not more than one Tangram instance is allowed.
+        console.log('Tangram is already on the page.');
+      }
+      return this;
+    },
+
+
+    _setupScene: function() {
+      // Set up scene when Tangram object is available
+      if (typeof Tangram === 'undefined') {
+        return window.setTimeout(this._setupScene.bind(this), 100);
+      } else {
+        if (this._hasWebGL()) {
+          console.log('given scene:', this.options.scene);
+          console.log('using scene:', (this.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
+          Tangram.leafletLayer({
+            scene: (this.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
+          }).addTo(this.map);
+        } else {
+          // When WebGL is not avilable
+          console.log('WebGL is not available, falling back to OSM default tile.');
+          L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+          }).addTo(this.map);
+        }
+      }
+    },
+
+    _importScript: function(sSrc) {
+      var oScript = document.createElement('script');
+
+      oScript.type = 'text/javascript';
+      oScript.onerror = this._loadError;
+      oScript.onload = this._setupScene.bind(this);
+      if (document.currentScript) document.currentScript.parentNode.insertBefore(oScript, document.currentScript);
+      // If browser doesn't support currentscript position
+      // insert script inside of head
+      else document.getElementsByTagName('head')[0].appendChild(oScript);
+      oScript.src = sSrc;
+    },
+
+    _loadError: function(oError) {
+      console.log(oError);
+      throw new URIError('The script ' + oError.target.src + ' is not accessible.');
+    },
+
+    _hasWebGL: function() {
+      try {
+        var canvas = document.createElement('canvas');
+        return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+      } catch (x) {
+        return false;
+      }
+    }
   };
 
-  var importScript = function (sSrc) {
-    oScript = document.createElement('script');
-
-    oScript.type = 'text/javascript';
-    oScript.onerror = loadError;
-    if (document.currentScript) document.currentScript.parentNode.insertBefore(oScript, document.currentScript);
-    // If browser doesn't support currentscript position
-    // insert script inside of head
-    else document.getElementsByTagName('head')[0].appendChild(oScript);
-    oScript.src = sSrc;
-  };
-
-  // Start importing script as soon as Mapzen.js started
-  // When there is no Tangram object available.
-  if (typeof Tangram === 'undefined') importScript(tangramScriptURL);
-  // Return script element to get onload event from
   return {
-    scriptEl: oScript
+    addTo: function (map, options) {
+      if (!tangramLayerInstance) {
+        tangramLayerInstance = tangramLayer.init(map, options);
+      } else {
+        console.log('Only one Tangram map on page can be drawn. Please look at https://github.com/tangrams/tangram/issues/350');
+      }
+      return tangramLayerInstance;
+    }
   };
+
 })();
 
-module.exports = TangramScript;
+module.exports = TangramLayer;

--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -7,7 +7,6 @@ var Bug = require('./components/bug');
 var Locator = require('./components/locator');
 var Geocoder = require('./components/search');
 var Hash = require('./components/hash');
-var TangramScript = require('./components/tangram');
 var HouseStyles = require('./components/houseStyles');
 
 L.Mapzen = module.exports = {
@@ -16,6 +15,5 @@ L.Mapzen = module.exports = {
   locator: Locator.locator,
   bug: Bug,
   hash: Hash.hash,
-  HouseStyles: HouseStyles,
-  _tangramScript: TangramScript
+  HouseStyles: HouseStyles
 };

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -34,7 +34,7 @@ module.exports = function (config) {
 
     client: {
       mocha: {
-        timeout : 5000 // 5 seconds - upped from default 2 seconds
+        timeout: 5000 // 5 seconds - upped from default 2 seconds
       }
     },
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -18,7 +18,8 @@ module.exports = function (config) {
       'node_modules/expect.js/index.js',
       'node_modules/happen/happen.js',
       'dist/mapzen.js',
-      'test/spec/*.js',
+      'test/spec/mapControl.js',
+      'test/spec/hash.js'
     ],
 
     plugins: [

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -20,7 +20,7 @@ describe('Map Hash Test', function () {
   describe('Hash Working', function () {
     it('checks that hash for coord is working', function () {
       var map = L.Mapzen.map(el,{
-        useTangram: false
+        _useTangram: false
       });
       map.setView([51.505, -0.09], 13);
       L.Mapzen.hash({

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -19,7 +19,9 @@ describe('Map Hash Test', function () {
 
   describe('Hash Working', function () {
     it('checks that hash for coord is working', function () {
-      var map = L.Mapzen.map(el);
+      var map = L.Mapzen.map(el,{
+        useTangram: false
+      });
       map.setView([51.505, -0.09], 13);
       L.Mapzen.hash({
         map: map

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -13,8 +13,6 @@ describe('Map Control Test', function () {
 
   describe('Tangram check', function () {
     it('checks default style is set.', function (done) {
-
-
       var _hasWebGL = function() {
         try {
           var canvas = document.createElement('canvas');
@@ -23,9 +21,9 @@ describe('Map Control Test', function () {
           return false;
         }
       }
+      var thisMap = L.Mapzen.map(el);
       // Give time to load Tangram script
       setTimeout(function () {
-        var thisMap = L.Mapzen.map(el);
         if (_hasWebGL()) {
           thisMap.eachLayer(function (layer) {
             if (layer.scene) done();

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -13,10 +13,20 @@ describe('Map Control Test', function () {
 
   describe('Tangram check', function () {
     it('checks default style is set.', function (done) {
+
+
+      var _hasWebGL = function() {
+        try {
+          var canvas = document.createElement('canvas');
+          return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+        } catch (x) {
+          return false;
+        }
+      }
       // Give time to load Tangram script
       setTimeout(function () {
         var thisMap = L.Mapzen.map(el);
-        if (thisMap._hasWebGL()) {
+        if (_hasWebGL()) {
           thisMap.eachLayer(function (layer) {
             if (layer.scene) done();
           });


### PR DESCRIPTION
- Moved Tangram related  functions to Tangram object 
- Made Tangram singleton, when user tries to initialize more than one map, it throws an error and shows link to see the details https://github.com/tangrams/tangram/issues/350
- Tangram layer object is mimicking Leaflet's control behavior, added by `addTo(map)` function to main map layer. This decision is mainly for near future when other components (Routing) wants to access to Tangram layer without putting Tangram layer to the map. Even if TangramLayer object itself is singleton, there is no way to prevent this `addTo` function to be executed more than one time now. The only case that I can imagine this will make problem is somebody pokes mapzen.js source file directly, so I left it as it is now.
- added `useTangram` option of which default is `true`. (It directly benefits test env where many maps are created and discarded) I made that option not public now. 👉 hopefully this will make test less suck.
