### PR TITLE
Detect webgl first, set fallbacktile as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Map Options
 
 | `attribution` | Object | `{url:'http://{s}.tile.osm.org/{z}/{x}/{y}.png', attribution: '' }` | Tile to fall back when WebGL is not available. |
 | `scene` | String | `L.Mapzen.HouseStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.HouseStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
-| `fallBackTile` | [L.tileLayer](http://leafletjs.com/reference.html#tilelayer) | `L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {})` | Tilelayer to fall back when WebGL is not available. |
+| `fallBackTile` | [L.TileLayer](http://leafletjs.com/reference.html#tilelayer) | `L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {})` | Tilelayer to fall back when WebGL is not available. |
 
 ### Geocoder Control
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Map Options
 | Option  | Type   | Default                           | Description                                                   |
 |---------|--------|-----------------------------------|---------------------------------------------------------------|
 | `scene` | String | `L.Mapzen.HouseStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.HouseStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
-
+| `fallBackTile` | object | `{url:'http://{s}.tile.osm.org/{z}/{x}/{y}.png', attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>' }` | Tile to fall back when WebGL is not available. |
 
 ### Geocoder Control
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The HTML below represents the minimum structure to display the map centered on N
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link rel="stylesheet" href="https://mapzen.com/js/mapzen.css">
     <script src="https://mapzen.com/js/mapzen.min.js"></script>
+    <style>
+    </style>
   </head>
   <body>
     <div id="map"></div>
@@ -50,7 +52,7 @@ Map Options
 | Option  | Type   | Default                           | Description                                                   |
 |---------|--------|-----------------------------------|---------------------------------------------------------------|
 | `scene` | String | `L.Mapzen.HouseStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.HouseStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
-| `fallBackTile` | object | `{url:'http://{s}.tile.osm.org/{z}/{x}/{y}.png', attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>' }` | Tile to fall back when WebGL is not available. |
+| `fallBackTile` | Object | `{url:'http://{s}.tile.osm.org/{z}/{x}/{y}.png', attribution: '' }` | Tile to fall back when WebGL is not available. |
 
 ### Geocoder Control
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,9 @@ Map Options
 
 | Option  | Type   | Default                           | Description                                                   |
 |---------|--------|-----------------------------------|---------------------------------------------------------------|
-
-| `attribution` | Object | `{url:'http://{s}.tile.osm.org/{z}/{x}/{y}.png', attribution: '' }` | Tile to fall back when WebGL is not available. |
 | `scene` | String | `L.Mapzen.HouseStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.HouseStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
 | `fallBackTile` | [L.TileLayer](http://leafletjs.com/reference.html#tilelayer) | `L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {})` | Tilelayer to fall back when WebGL is not available. |
+| `attributionText` | String | `<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors` | Attribution data  in a small text box, which displayes before `Leaflet` attribution |
 
 ### Geocoder Control
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Map Options
 |---------|--------|-----------------------------------|---------------------------------------------------------------|
 | `scene` | String | `L.Mapzen.HouseStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.HouseStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
 | `fallBackTile` | [L.TileLayer](http://leafletjs.com/reference.html#tilelayer) | `L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {})` | Tilelayer to fall back when WebGL is not available. |
-| `attributionText` | String | `<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors` | Attribution data  in a small text box, which displayes before `Leaflet` attribution |
+| `attributionText` | String | `<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors` | Attribution data  in a small text box.`Leaflet` attribution is always there, attribution from this option is placed before `Leaflet` attribution.|
 
 ### Geocoder Control
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Map Options
 
 | `attribution` | Object | `{url:'http://{s}.tile.osm.org/{z}/{x}/{y}.png', attribution: '' }` | Tile to fall back when WebGL is not available. |
 | `scene` | String | `L.Mapzen.HouseStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.HouseStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
-| `fallBackTile` | Object | `{url:'http://{s}.tile.osm.org/{z}/{x}/{y}.png', attribution: '' }` | Tile to fall back when WebGL is not available. |
+| `fallBackTile` | [L.tileLayer](http://leafletjs.com/reference.html#tilelayer) | `L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {})` | Tilelayer to fall back when WebGL is not available. |
 
 ### Geocoder Control
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ The HTML below represents the minimum structure to display the map centered on N
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link rel="stylesheet" href="https://mapzen.com/js/mapzen.css">
     <script src="https://mapzen.com/js/mapzen.min.js"></script>
-    <style>
-    </style>
   </head>
   <body>
     <div id="map"></div>
@@ -51,6 +49,8 @@ Map Options
 
 | Option  | Type   | Default                           | Description                                                   |
 |---------|--------|-----------------------------------|---------------------------------------------------------------|
+
+| `attribution` | Object | `{url:'http://{s}.tile.osm.org/{z}/{x}/{y}.png', attribution: '' }` | Tile to fall back when WebGL is not available. |
 | `scene` | String | `L.Mapzen.HouseStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.HouseStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
 | `fallBackTile` | Object | `{url:'http://{s}.tile.osm.org/{z}/{x}/{y}.png', attribution: '' }` | Tile to fall back when WebGL is not available. |
 

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -26,28 +26,27 @@ var TangramLayer = (function () {
 
     addTo: function (map) {
       // Set up scene when Tangram object is available
-
-        if (this._hasWebGL()) {
-          if (typeof Tangram === 'undefined') {
-            return window.setTimeout(this.addTo.bind(this, map), 100);
-          } else {
-            console.log('given scene:', map.options.scene);
-            console.log('using scene:', (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
-            var layer = Tangram.leafletLayer({
-              scene: (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
-            }).addTo(map);
-            return layer;
-          }
+      if (this._hasWebGL()) {
+        if (typeof Tangram === 'undefined') {
+          return window.setTimeout(this.addTo.bind(this, map), 100);
         } else {
-          if(map.options.fallbackTile) {
-            console.log('WebGL is not available, falling back to fallbackTile option.');
-            map.options.fallbackTile.addTo(map);
-          } else {
-          // When WebGL is not avilable
-            console.log('WebGL is not available, falling back to OSM default tile.');
-            L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {}).addTo(map);
-          }
+          console.log('given scene:', map.options.scene);
+          console.log('using scene:', (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
+          var layer = Tangram.leafletLayer({
+            scene: (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
+          }).addTo(map);
+          return layer;
         }
+      } else {
+        if (map.options.fallbackTile) {
+          console.log('WebGL is not available, falling back to fallbackTile option.');
+          map.options.fallbackTile.addTo(map);
+        } else {
+        // When WebGL is not avilable
+          console.log('WebGL is not available, falling back to OSM default tile.');
+          L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {}).addTo(map);
+        }
+      }
     },
 
     _importScript: function (sSrc) {

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -39,17 +39,15 @@ var TangramLayer = (function () {
             return layer;
           }
         } else {
-          if(option.fallbackTile) {
+          if(map.options.fallbackTile) {
             console.log('WebGL is not available, falling back to fallbackTile option.');
-            L.tileLayer(fallbackTile.url, {
-              attribution: fallbackTile.attribution
+            L.tileLayer(map.options.fallbackTile.url, {
+              attribution: map.options.fallbackTile.attribution
             }).addTo(map);
           } else {
           // When WebGL is not avilable
             console.log('WebGL is not available, falling back to OSM default tile.');
-            L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-              attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
-            }).addTo(map);
+            L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {}).addTo(map);
           }
         }
     },

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -33,16 +33,24 @@ var TangramLayer = (function () {
           } else {
             console.log('given scene:', map.options.scene);
             console.log('using scene:', (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
-            Tangram.leafletLayer({
+            var layer = Tangram.leafletLayer({
               scene: (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
             }).addTo(map);
+            return layer;
           }
         } else {
+          if(option.fallbackTile) {
+            console.log('WebGL is not available, falling back to fallbackTile option.');
+            L.tileLayer(fallbackTile.url, {
+              attribution: fallbackTile.attribution
+            }).addTo(map);
+          } else {
           // When WebGL is not avilable
-          console.log('WebGL is not available, falling back to OSM default tile.');
-          L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
-          }).addTo(map);
+            console.log('WebGL is not available, falling back to OSM default tile.');
+            L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+              attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+            }).addTo(map);
+          }
         }
     },
 

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -41,9 +41,7 @@ var TangramLayer = (function () {
         } else {
           if(map.options.fallbackTile) {
             console.log('WebGL is not available, falling back to fallbackTile option.');
-            L.tileLayer(map.options.fallbackTile.url, {
-              attribution: map.options.fallbackTile.attribution
-            }).addTo(map);
+            map.options.fallbackTile.addTo(map);
           } else {
           // When WebGL is not avilable
             console.log('WebGL is not available, falling back to OSM default tile.');

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -26,15 +26,17 @@ var TangramLayer = (function () {
 
     addTo: function (map) {
       // Set up scene when Tangram object is available
-      if (typeof Tangram === 'undefined') {
-        return window.setTimeout(this.addTo.bind(this, map), 100);
-      } else {
+
         if (this._hasWebGL()) {
-          console.log('given scene:', map.options.scene);
-          console.log('using scene:', (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
-          Tangram.leafletLayer({
-            scene: (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
-          }).addTo(map);
+          if (typeof Tangram === 'undefined') {
+            return window.setTimeout(this.addTo.bind(this, map), 100);
+          } else {
+            console.log('given scene:', map.options.scene);
+            console.log('using scene:', (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
+            Tangram.leafletLayer({
+              scene: (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
+            }).addTo(map);
+          }
         } else {
           // When WebGL is not avilable
           console.log('WebGL is not available, falling back to OSM default tile.');
@@ -42,7 +44,6 @@ var TangramLayer = (function () {
             attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
           }).addTo(map);
         }
-      }
     },
 
     _importScript: function (sSrc) {


### PR DESCRIPTION
- https://github.com/mapzen/data-pages/issues/164
- detect webgl first, so users without webgl dont' need to wait for Tangram to be loaded on the page
- set `fallbackTile` as option of which type is [L.TileLayer](http://leafletjs.com/reference.html#tilelayer)