### PR TITLE
checked Tangramlayer for test

### DIFF
--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -23,18 +23,24 @@ describe('Map Control Test', function () {
       }
       var thisMap = L.Mapzen.map(el);
       // Give time to load Tangram script
-      setTimeout(function () {
+      var count = 0;
+
+      var checkTangramLayer = function () {
+        var tangramLayer;
+        thisMap.eachLayer(function (layer) {
+          if (layer.scene) tangramLayer = layer;
+        });
         if (_hasWebGL()) {
-          thisMap.eachLayer(function (layer) {
-            if (layer.scene) done();
-          });
-          // If no layer with scene found, break the test.
-          done(new Error('No Tangram scene found.'));
+          if (tangramLayer === undefined && count < 20) return setTimeout(checkTangramLayer.bind(this), 200);
+          else if (tangramLayer) done();
+          else if (count >= 20) done(new Error('takes too long to load Tangram'))
         } else {
-          // When WebGL is not avilable, skip the test.
           done();
         }
-      }, 1500);
+      }
+
+      checkTangramLayer();
+
     });
   })
 });


### PR DESCRIPTION
- Before, test set timeout (1.5 sec) in a hope that Tangram is loaded meanwhile. <-I think this is why the test failed sometimes. Tangram sometimes loaded over Browserstack fast, sometimes not. Now, it checks Tangram every 0.2 sec that it was loaded or not, for maximum 4 secs. Hopefully this will fix test displease. 
- closes #200 (hopefully)