### PR TITLE
Exposed Tangram api through event 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "dev": " cp src/dev.html dist/index.html; watchify  ./src/js/mapzen.js -o dist/mapzen.min.js -v;",
     "build": "browserify ./src/js/mapzen.js > dist/mapzen.js; browserify -t uglifyify ./src/js/mapzen.js | uglifyjs -c > dist/mapzen.min.js; cp src/index.html dist/; npm run-script build-style;"
   },
-  "dependencies": {
-
-  },
+  "dependencies": {},
   "devDependencies": {
     "benchmark": "^2.1.0",
     "browserify": "^13.0.0",
@@ -44,6 +42,7 @@
     "mocha": "^2.4.5",
     "node-sass": "^3.7.0",
     "phantomjs-prebuilt": "^2.1.7",
+    "promise-polyfill": "^6.0.1",
     "requirejs": "^2.2.0",
     "sinon": "^1.17.3",
     "uglifyify": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "mocha": "^2.4.5",
     "node-sass": "^3.7.0",
     "phantomjs-prebuilt": "^2.1.7",
-    "promise-polyfill": "^6.0.1",
     "requirejs": "^2.2.0",
     "sinon": "^1.17.3",
     "uglifyify": "^3.0.1",

--- a/src/index.html
+++ b/src/index.html
@@ -61,6 +61,11 @@
         geocoder: geocoder
       });
 
+      var tangram = L.Mapzen.tangram();
+      tangram.on('loaded', function(layer) {
+        console.log(layer);
+      })
+
     </script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -62,8 +62,8 @@
       });
 
       var tangram = L.Mapzen.tangram();
-      tangram.on('loaded', function(layer) {
-        console.log(layer);
+      tangram.on('loaded', function(e) {
+        console.log(e.layer);
       })
 
     </script>

--- a/src/index.html
+++ b/src/index.html
@@ -62,7 +62,7 @@
       });
 
       var tangram = L.Mapzen.tangram();
-      // This is likely to fail, since Tangram is not loaded in async.
+      // This is likely to fail, since Tangram is loaded in async.
       // If Tangram is not loaded, this will log 'Tangram is not loaded yet. Please use the loaded event'
       var failingTangramLayer = tangram.getLayer();
 

--- a/src/index.html
+++ b/src/index.html
@@ -61,16 +61,10 @@
         geocoder: geocoder
       });
 
-      var tangram = L.Mapzen.tangram();
-      // This is likely to fail, since Tangram is loaded in async.
-      // If Tangram is not loaded, this will log 'Tangram is not loaded yet. Please use the loaded event'
-      var failingTangramLayer = tangram.getLayer();
+      map.on('tangramloaded', function(e) {
+        console.log(e.tangramLayer);
+      });
 
-      tangram.on('loaded', function(e) {
-        // Both have same result
-        console.log(e.layer);
-        console.log(tangram.getLayer());
-      })
     </script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -62,10 +62,13 @@
       });
 
       var tangram = L.Mapzen.tangram();
-      tangram.on('loaded', function(e) {
-        console.log(e.layer);
-      })
+      var failingTangramLayer = tangram.getLayer();
 
+      tangram.on('loaded', function(e) {
+        // Both have same result
+        console.log(e.layer);
+        console.log(tangram.getLayer());
+      })
     </script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -62,6 +62,8 @@
       });
 
       var tangram = L.Mapzen.tangram();
+      // This is likely to fail, since Tangram is not loaded in async.
+      // If Tangram is not loaded, this will log 'Tangram is not loaded yet. Please use the loaded event'
       var failingTangramLayer = tangram.getLayer();
 
       tangram.on('loaded', function(e) {

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -1,6 +1,5 @@
 'use strict';
 var L = require('leaflet');
-var TangramLayer = require('./tangram');
 
 var MapControl = L.Map.extend({
   options: {
@@ -11,12 +10,11 @@ var MapControl = L.Map.extend({
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
-
+    console.log(this.options.scene);
     if (this.options._useTangram) {
-      var tangramLayer = TangramLayer.init();
-      tangramLayer.addTo(this);
+      var tangram = L.Mapzen.tangram();
+      tangram.addTo(this);
     }
-
     // Adding Mapzen attribution to Leaflet
     if (this.attributionControl) {
       this.attributionControl.setPrefix('');

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -13,7 +13,7 @@ var MapControl = L.Map.extend({
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
 
     if (this.options._useTangram) {
-      var tangram = L.Mapzen.tangram();
+      var tangram = L.Mapzen._tangram();
       tangram.addTo(this);
       var self = this;
       tangram.on('loaded', function (e) {

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -2,6 +2,7 @@
 var L = require('leaflet');
 
 var MapControl = L.Map.extend({
+  includes: L.Mixin.Events,
   options: {
     attributionText: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors',
     _useTangram: true
@@ -10,10 +11,18 @@ var MapControl = L.Map.extend({
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
+
     if (this.options._useTangram) {
       var tangram = L.Mapzen.tangram();
       tangram.addTo(this);
+      var self = this;
+      tangram.on('loaded', function (e) {
+        self.fire('tangramloaded', {
+          tangramLayer: e.layer
+        });
+      })
     }
+
     // Adding Mapzen attribution to Leaflet
     if (this.attributionControl) {
       this.attributionControl.setPrefix('');

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -10,7 +10,6 @@ var MapControl = L.Map.extend({
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
     L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
-    console.log(this.options.scene);
     if (this.options._useTangram) {
       var tangram = L.Mapzen.tangram();
       tangram.addTo(this);

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -23,13 +23,12 @@ var TangramLayer = L.Class.extend({
       // Not more than one Tangram instance is allowed.
       // console.log('Tangram is already on the page.');
     }
-
   },
 
   addTo: function (map) {
     var self = this;
 
-    this.scriptLoadedPromise.then( function () {
+    this.scriptLoadedPromise.then(function () {
       if (self._hasWebGL()) {
         console.log('given scene:', map.options.scene);
         console.log('using scene:', (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
@@ -39,8 +38,7 @@ var TangramLayer = L.Class.extend({
 
         self.fire('loaded', {
           layer: _layer
-        })
-
+        });
       } else {
         if (map.options.fallbackTile) {
           console.log('WebGL is not available, falling back to fallbackTile option.');
@@ -51,7 +49,7 @@ var TangramLayer = L.Class.extend({
           self.options.fallbackTile.addTo(map);
         }
       }
-    })
+    });
   },
 
   _importScript: function (sSrc) {
@@ -90,4 +88,4 @@ module.exports.tangramLayer = function () {
     // console.log('Only one Tangram map on page can be drawn. Please look at https://github.com/tangrams/tangram/issues/350');
   }
   return tangramLayerInstance;
-}
+};

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -34,6 +34,10 @@ var TangramLayer = L.Class.extend({
         var _layer = Tangram.leafletLayer({
           scene: (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
         }).addTo(map);
+
+        this.layer = _layer;
+        this._layerLoaded = true;
+
         this.fire('loaded', {
           layer: _layer
         });
@@ -47,6 +51,13 @@ var TangramLayer = L.Class.extend({
         console.log('WebGL is not available, falling back to OSM default tile.');
         this.options.fallbackTile.addTo(map);
       }
+    }
+  },
+  getLayer: function () {
+    if (this._layerLoaded === true) {
+      return this.layer;
+    } else {
+      console.log('Tangram is not loaded yet. Please use the loaded event');
     }
   },
   _importScript: function (sSrc) {

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -37,7 +37,6 @@ var TangramLayer = L.Class.extend({
 
         this.layer = _layer;
         this._layerLoaded = true;
-
         this.fire('loaded', {
           layer: _layer
         });
@@ -53,13 +52,13 @@ var TangramLayer = L.Class.extend({
       }
     }
   },
-  getLayer: function () {
-    if (this._layerLoaded === true) {
-      return this.layer;
-    } else {
-      console.log('Tangram is not loaded yet. Please use the loaded event');
-    }
-  },
+  // getLayer: function () {
+  //   if (this._layerLoaded === true) {
+  //     return this.layer;
+  //   } else {
+  //     console.log('Tangram is not loaded yet. Please use the loaded event');
+  //   }
+  // },
   _importScript: function (sSrc) {
     var oScript = document.createElement('script');
     oScript.type = 'text/javascript';
@@ -83,7 +82,6 @@ var TangramLayer = L.Class.extend({
       return false;
     }
   }
-
 });
 
 module.exports = TangramLayer;

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -2,91 +2,92 @@
 // (either as a URL or full string of all source code) in order to load itself into web workers
 // This script injects the Tangram with script tag, so that Tangram doesn't need to be included with outside tag
 var L = require('leaflet');
+var Promise = require('promise-polyfill');
 
-var TangramLayer = (function () {
-  var tangramLayerInstance;
+var tangramLayerInstance;
 
-  var tangramLayer = {
-    init: function () {
-      // Start importing script as soon as Mapzen.js started
-      // When there is no Tangram object available.
-      if (typeof Tangram === 'undefined') {
-        var tangramScriptURL = 'https://mapzen.com/tangram/0.8/tangram.min.js';
-        this._importScript(tangramScriptURL);
-      } else {
-        // Not more than one Tangram instance is allowed.
-        console.log('Tangram is already on the page.');
-      }
-      return this;
-    },
+var TangramLayer = L.Class.extend({
+  includes: L.Mixin.Events,
+  options: {
+    fallbackTile: L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {}),
+    tangramURL: 'https://mapzen.com/tangram/0.8/tangram.min.js'
+  },
 
-    // Mimicks Leaflet control behavior
-    // This function can't be executed more than one time because of Tangram issue
-    // https://github.com/tangrams/tangram/issues/350
+  initialize: function () {
+    // Start importing script
+    // When there is no Tangram object available.
+    if (typeof Tangram === 'undefined') {
+      var tangramScriptURL = 'https://mapzen.com/tangram/0.8/tangram.min.js';
+      this._importScript(tangramScriptURL);
+    } else {
+      // Not more than one Tangram instance is allowed.
+      // console.log('Tangram is already on the page.');
+    }
 
-    addTo: function (map) {
-      // Set up scene when Tangram object is available
-      if (this._hasWebGL()) {
-        if (typeof Tangram === 'undefined') {
-          return window.setTimeout(this.addTo.bind(this, map), 100);
-        } else {
-          console.log('given scene:', map.options.scene);
-          console.log('using scene:', (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
-          var layer = Tangram.leafletLayer({
-            scene: (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
-          }).addTo(map);
-          return layer;
-        }
+  },
+
+  addTo: function (map) {
+    var self = this;
+
+    this.scriptLoadedPromise.then( function () {
+      if (self._hasWebGL()) {
+        console.log('given scene:', map.options.scene);
+        console.log('using scene:', (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap));
+        var _layer = Tangram.leafletLayer({
+          scene: (map.options.scene || L.Mapzen.HouseStyles.BubbleWrap)
+        }).addTo(map);
+
+        self.fire('loaded', {
+          layer: _layer
+        })
+
       } else {
         if (map.options.fallbackTile) {
           console.log('WebGL is not available, falling back to fallbackTile option.');
-          map.options.fallbackTile.addTo(map);
+          self.options.fallbackTile.addTo(map);
         } else {
         // When WebGL is not avilable
           console.log('WebGL is not available, falling back to OSM default tile.');
-          L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {}).addTo(map);
+          self.options.fallbackTile.addTo(map);
         }
       }
-    },
+    })
+  },
 
-    _importScript: function (sSrc) {
+  _importScript: function (sSrc) {
+    this.scriptLoadedPromise = new Promise(function (resolve, reject) {
       var oScript = document.createElement('script');
-
       oScript.type = 'text/javascript';
-      oScript.onerror = this._loadError;
+      oScript.onerror = reject;
+      oScript.onload = resolve;
 
       if (document.currentScript) document.currentScript.parentNode.insertBefore(oScript, document.currentScript);
       // If browser doesn't support currentscript position
       // insert script inside of head
       else document.getElementsByTagName('head')[0].appendChild(oScript);
       oScript.src = sSrc;
-    },
+    });
+  },
 
-    _loadError: function (oError) {
-      console.log(oError);
-      throw new URIError('The script ' + oError.target.src + ' is not accessible.');
-    },
-
-    _hasWebGL: function () {
-      try {
-        var canvas = document.createElement('canvas');
-        return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
-      } catch (x) {
-        return false;
-      }
+  _hasWebGL: function () {
+    try {
+      var canvas = document.createElement('canvas');
+      return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+    } catch (x) {
+      return false;
     }
-  };
+  }
 
-  return {
-    init: function (map) {
-      if (!tangramLayerInstance) {
-        tangramLayerInstance = tangramLayer.init(map);
-      } else {
-        console.log('Only one Tangram map on page can be drawn. Please look at https://github.com/tangrams/tangram/issues/350');
-      }
-      return tangramLayerInstance;
-    }
-  };
-})();
+});
 
 module.exports = TangramLayer;
+
+module.exports.tangramLayer = function () {
+  // Tangram can't have more than one map on a browser context.
+  if (!tangramLayerInstance) {
+    tangramLayerInstance = new TangramLayer();
+  } else {
+    // console.log('Only one Tangram map on page can be drawn. Please look at https://github.com/tangrams/tangram/issues/350');
+  }
+  return tangramLayerInstance;
+}

--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -8,7 +8,6 @@ var Locator = require('./components/locator');
 var Geocoder = require('./components/search');
 var Hash = require('./components/hash');
 var BasemapStyles = require('./components/basemapStyles');
-var TangramLayer = require('./components/tangram');
 
 L.Mapzen = module.exports = {
   map: MapControl.map,
@@ -17,6 +16,5 @@ L.Mapzen = module.exports = {
   bug: Bug,
   hash: Hash.hash,
   HouseStyles: BasemapStyles,
-  BasemapStyles: BasemapStyles,
-  tangram: TangramLayer.tangramLayer
+  BasemapStyles: BasemapStyles
 };

--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -8,7 +8,7 @@ var Locator = require('./components/locator');
 var Geocoder = require('./components/search');
 var Hash = require('./components/hash');
 var BasemapStyles = require('./components/basemapStyles');
-var TangramLayer = require('./components/tangram')
+var TangramLayer = require('./components/tangram');
 
 L.Mapzen = module.exports = {
   map: MapControl.map,

--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -8,6 +8,7 @@ var Locator = require('./components/locator');
 var Geocoder = require('./components/search');
 var Hash = require('./components/hash');
 var BasemapStyles = require('./components/basemapStyles');
+var TangramLayer = require('./components/tangram')
 
 L.Mapzen = module.exports = {
   map: MapControl.map,
@@ -16,5 +17,6 @@ L.Mapzen = module.exports = {
   bug: Bug,
   hash: Hash.hash,
   HouseStyles: BasemapStyles,
-  BasemapStyles: BasemapStyles
+  BasemapStyles: BasemapStyles,
+  tangram: TangramLayer.tangramLayer
 };

--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -8,6 +8,7 @@ var Locator = require('./components/locator');
 var Geocoder = require('./components/search');
 var Hash = require('./components/hash');
 var BasemapStyles = require('./components/basemapStyles');
+var TangramLayer = require('./components/tangram')
 
 L.Mapzen = module.exports = {
   map: MapControl.map,
@@ -16,5 +17,6 @@ L.Mapzen = module.exports = {
   bug: Bug,
   hash: Hash.hash,
   HouseStyles: BasemapStyles,
-  BasemapStyles: BasemapStyles
+  BasemapStyles: BasemapStyles,
+  _tangram: TangramLayer.tangramLayer
 };


### PR DESCRIPTION
- There has been needs for exposing Tangram feature through `mapzen.js`. Before, users loop through each layer of Leaflet and grab [a Tangram layer](https://github.com/mapzen/mapzen.js/issues/195)
- This commit exposed `tangram` wrapper object through `L.Mapzen.tangram`, specifically tangram layer through event `loaded`. You can see how to use the event at [here](https://github.com/mapzen/mapzen.js/blob/hanb/tangram-promise/src/index.html#L64). 
- Current change tries to follow Leaflet plugin's syntax. I wonder this style of syntax doesn't make it clear for users that `L.Mapzen.tangram` can't actually be used to set Tangram scene or fallback tiles. 
- @bcamper @binx I will appreciate any feedback! 
- @rmglennon letting you know about this API change.
- closes #203 