### PR TITLE
add link to locator project in the documentation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -93,7 +93,7 @@ Bug Options
 
 ## Locator control
 
-`L.Mapzen.locator` adds a geolocation control to the map. This integrates the [Leaflet.Locator control](https://github.com/domoritz/leaflet-locatecontrol); see that project's documentation for additional options.
+`L.Mapzen.locator` adds a geolocation control to the map. This integrates the [Leaflet.Locator control](https://github.com/domoritz/leaflet-locatecontrol); see that project's [documentation](https://github.com/domoritz/leaflet-locatecontrol/blob/gh-pages/README.md) for additional options.
 
 ``` javascript
 var locator = L.Mapzen.locator();

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -93,7 +93,7 @@ Bug Options
 
 ## Locator control
 
-`L.Mapzen.locator` adds a geolocation control to the map.
+`L.Mapzen.locator` adds a geolocation control to the map. This integrates the [Leaflet.Locator control](https://github.com/domoritz/leaflet-locatecontrol); see that project's documentation for additional options.
 
 ``` javascript
 var locator = L.Mapzen.locator();


### PR DESCRIPTION
We have a generic link in our readme, but nothing in the documentation that specifically directs people to that project. The readme has options and available methods.

Fixes #216 