### PR TITLE
set image path manually

### DIFF
--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -20,7 +20,7 @@ var MapControl = L.Map.extend({
         self.fire('tangramloaded', {
           tangramLayer: e.layer
         });
-      })
+      });
     }
 
     // Adding Mapzen attribution to Leaflet
@@ -30,8 +30,6 @@ var MapControl = L.Map.extend({
       this.attributionControl.addAttribution(tempAttr);
       this.attributionControl.addAttribution('<a href="http://leafletjs.com/">Leaflet</a>');
     }
-    // Set Icon path manually
-    L.Icon.Default.imagePath = this._getImagePath();
 
     // overriding double click behaviour to zoom up where it is clicked
     this.doubleClickZoom.disable();
@@ -39,24 +37,6 @@ var MapControl = L.Map.extend({
       this.setView(e.latlng, this.getZoom() + 1);
     });
     this._checkConditions(false);
-  },
-
-  _getImagePath: function () {
-    // Modified Leaflet's Image Path function
-    var scripts = document.getElementsByTagName('script');
-    var mapzenRe = /[\/^]mapzen[\-\._]?([\w\-\._]*)\.js\??/;
-
-    var i, len, src, matches, path;
-
-    for (i = 0, len = scripts.length; i < len; i++) {
-      src = scripts[i].src;
-      matches = src.match(mapzenRe);
-
-      if (matches) {
-        path = src.split(mapzenRe)[0];
-        return (path ? path + '/' : '') + 'images';
-      }
-    }
   },
 
   _checkConditions: function (force) {

--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -8,7 +8,7 @@ var Locator = require('./components/locator');
 var Geocoder = require('./components/search');
 var Hash = require('./components/hash');
 var BasemapStyles = require('./components/basemapStyles');
-var TangramLayer = require('./components/tangram')
+var TangramLayer = require('./components/tangram');
 
 L.Mapzen = module.exports = {
   map: MapControl.map,
@@ -20,3 +20,6 @@ L.Mapzen = module.exports = {
   BasemapStyles: BasemapStyles,
   _tangram: TangramLayer.tangramLayer
 };
+
+// Set Icon Path manually (Leaflet detects the path based on where Leaflet script is)
+L.Icon.Default.imagePath = 'https://mapzen.com/js/images';


### PR DESCRIPTION
- Leaflet sets image path based on where Leaflet is. Since mapzen.js embedded Leaflet inside of it, plugins based on Leaflet's image path throws error. 
- One concern is I can't specify the version number of mapzen.js for the image path. I can set it manually but can't think of smarter way to do this 💭 