### PR TITLE
Moved CIRCLE_TAG use exclusively to circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,8 +13,8 @@ deployment:
   release:
     tag: /release-v[0-9]+(\.[0-9])+/
     commands:
-      - ./deploy.sh static-dev.mapzen.com ${CIRCLE_TAG#release-v}
-      - ./deploy.sh static-prod.mapzen.com ${CIRCLE_TAG#release-v}
+      - ./deploy.sh ${CIRCLE_TAG#release-v} static-dev.mapzen.com
+      - ./deploy.sh ${CIRCLE_TAG#release-v} static-prod.mapzen.com
       # npm release process
       - echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_ACCOUNT" | npm login
       - npm version ${CIRCLE_TAG#release-v} --no-git-tag-version && publish --on-major --on-minor --on-patch

--- a/circle.yml
+++ b/circle.yml
@@ -13,8 +13,8 @@ deployment:
   release:
     tag: /release-v[0-9]+(\.[0-9])+/
     commands:
-      - ./deploy.sh static-dev.mapzen.com
-      - ./deploy.sh static-prod.mapzen.com
+      - ./deploy.sh static-dev.mapzen.com ${CIRCLE_TAG#release-v}
+      - ./deploy.sh static-prod.mapzen.com ${CIRCLE_TAG#release-v}
       # npm release process
       - echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_ACCOUNT" | npm login
       - npm version ${CIRCLE_TAG#release-v} --no-git-tag-version && publish --on-major --on-minor --on-patch

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -e
 
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 {S3 bucket} {version number}"
+    exit 1
+fi
+
 BUCKET="${1}"
-VPATCH=`echo ${CIRCLE_TAG#release-v} | cut -d. -f1,2,3 -`
-VMINOR=`echo ${CIRCLE_TAG#release-v} | cut -d. -f1,2 -`
-VMAJOR=`echo ${CIRCLE_TAG#release-v} | cut -d. -f1 -`
+VPATCH=`echo ${2} | cut -d. -f1,2,3 -`
+VMINOR=`echo ${2} | cut -d. -f1,2 -`
+VMAJOR=`echo ${2} | cut -d. -f1 -`
 
 if aws s3 ls "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js"; then
     echo "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js already exits, checking diffs..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,10 +6,10 @@ if [ $# -ne 2 ]; then
     exit 1
 fi
 
-BUCKET="${1}"
-VPATCH=`echo ${2} | cut -d. -f1,2,3 -`
-VMINOR=`echo ${2} | cut -d. -f1,2 -`
-VMAJOR=`echo ${2} | cut -d. -f1 -`
+VPATCH=`echo ${1} | cut -d. -f1,2,3 -`
+VMINOR=`echo ${1} | cut -d. -f1,2 -`
+VMAJOR=`echo ${1} | cut -d. -f1 -`
+BUCKET="${2}"
 
 if aws s3 ls "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js"; then
     echo "s3://${BUCKET}/js/${VPATCH}/mapzen.min.js already exits, checking diffs..."


### PR DESCRIPTION
Only Circle CI config should know about `$CIRCLE_TAG`; `deploy.sh` should only know about the version number as a value.