### PR TITLE
replaced test iphone device from 5s to 6s (ios7 -> ios9)

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -104,14 +104,14 @@ module.exports = function (config) {
         os: 'Windows',
         os_version: '10'
       },
-      bs_iphone5S: {
+      bs_iphone6S: {
         base: 'BrowserStack',
-        device: 'iPhone 5S',
+        device: 'iPhone 6S',
         os: 'ios',
-        os_version: '7.0'
+        os_version: '9.3'
       }
     },
 
-    browsers: ['PhantomJS', 'bs_iphone5S', 'bs_ie_window']
+    browsers: ['PhantomJS', 'bs_iphone6S', 'bs_ie_window']
   });
 };


### PR DESCRIPTION
- It seems [ios 9](https://developer.apple.com/support/app-store/) is dominant ios. Replacing current test with ios7 to the one with ios9. 