### PR TITLE
put link on noun and fix search link

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -66,14 +66,14 @@ _Note: L.Mapzen.HouseStyles has been deprecated for L.Mapzen.BasemapStyles. Star
 
 ## Geocoder control
 
-`L.Mapzen.geocoder` adds a Mapzen Search box to the map. [Create a Mapzen API key](https://mapzen.com/developers) to use the geocoder.
+`L.Mapzen.geocoder` adds a Mapzen Search box to the map. Create a [Mapzen API key](https://mapzen.com/developers) to use the geocoder.
 
 ```javascript
 var geocoder = L.Mapzen.geocoder('mapzen-api-key');
 geocoder.addTo(map);
 ```
 
-The geocoder has many options. See the [geocoder API reference](search) for more information.
+The geocoder has many options. See the [geocoder API reference](search.md) for more information.
 
 ## Bug (“Scarab”) Control
 


### PR DESCRIPTION
changes link to be on the noun "Mapzen API key"
fixes link to the search page (if it's search.md instead of search, it'll work on both GitHub and the formatted docs)