### PR TITLE
added syntax to totally disable scrollwheelzoom on any version of Leaflet

### DIFF
--- a/examples/standalone-v1.0.html
+++ b/examples/standalone-v1.0.html
@@ -41,18 +41,9 @@
         scene: L.Mapzen.BasemapStyles.Tron
       });
 
-
       map.setView([lat, lon],13);
 
       map.zoomControl.setPosition('bottomright');
-
-      function showMap(err, data) {
-        if (data.lbounds) {
-          map.fitBounds(data.lbounds);
-        } else if (data.latlng) {
-          map.setView([data.latlng[0], data.latlng[1]], 13);
-        }
-      }
 
       var locator = L.Mapzen.locator();
       locator.setPosition('bottomright');

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -38,6 +38,8 @@ var MapControl = L.Map.extend({
     if (this._isThisIframed()) {
       // do not scroll zoom when it is iframed
       this.scrollWheelZoom.disable();
+      this.scrollWheelZoom = false; // This is for Leaflet v1.0
+
       var anchors = document.querySelectorAll('a');
 
       for (var i = 0, j = anchors.length; i < j; i++) {


### PR DESCRIPTION
- not sure it is error or not, but Leaflet v1.0 doesn't disable scrollwheelzoom without redundant option setting