### PR TITLE
Image path fix 

### DIFF
--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -22,4 +22,6 @@ L.Mapzen = module.exports = {
 };
 
 // Set Icon Path manually (Leaflet detects the path based on where Leaflet script is)
-L.Icon.Default.imagePath = 'https://mapzen.com/js/images';
+// Leaflet 0.7 and < 1.0 handle image path differently
+if (parseFloat(L.version.substring(0,3)) < 1.0) L.Icon.Default.imagePath = 'https://mapzen.com/js/images';
+else L.Icon.Default.prototype.options.imagePath = 'https://mapzen.com/js/images/';


### PR DESCRIPTION
- Leaflet 1.0 and 0.7 expect different image paths. (also different way to put it) 
- closes #275 