### PR TITLE
hide zoomcontrol only when zoomControl option is true

### DIFF
--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -65,7 +65,9 @@ var MapControl = L.Map.extend({
   },
 
   _disableZoomControl: function () {
-    this.zoomControl._container.style.display = 'none';
+    if(this.options.zoomControl) {
+      this.zoomControl._container.hidden = true;
+    }
   }
 });
 


### PR DESCRIPTION
- closes #274 
- Also found the other problem that if zoomControl is added later than initialization of the map, this function really doesn't do anything.