### PR TITLE
Try npm tests multiple times?

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,8 @@ test:
   pre:
     - npm run build
     - npm run build-standalone
+  override:
+    - npm test || npm test || npm test
   post:
     - cp -Lr examples dist $CIRCLE_ARTIFACTS/
     - echo '<ul><li><a href="examples/index.html">Basic example</a></li><li><a href="examples/standalone.html">Standalone example</a></li><li><a href="examples/standalone-v1.0.html">Standalone + Leaflet 1.0 example</a></li></ul>' > $CIRCLE_ARTIFACTS/index.html


### PR DESCRIPTION
Seems like it might be possible to run `npm test` multiple times if it fails once, which might cut down on manual rebuilds.

* [x] See if this works.