### PR TITLE
bumped up the embedded Leaflet version to 1.0

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -35,7 +35,7 @@
         lat = 40.70531
       // creates a map with default (bubble-wrap) style
       var map = L.Mapzen.map('map', {
-        _debugTangram: true
+        debugTangram: true
       });
 
       map.setView([lat, lon],13);

--- a/examples/index.html
+++ b/examples/index.html
@@ -21,22 +21,22 @@
   </head>
   <body>
     <div id="map"></div>
-    <script src='https://geoiplookup.wikimedia.org/'></script>
-    <script src="../dist/mapzen.min.js"></script>
+    <script src="../dist/mapzen.js"></script>
     <script>
 
       var lat, lon;
        // when GeoIP is available, set the map's initial view to detected coordinates
-      if (typeof Geo === 'object') {
-        lon = Geo.lon
-        lat = Geo.lat
-      } else {
+      // if (typeof Geo === 'object') {
+      //   lon = Geo.lon
+      //   lat = Geo.lat
+      // } else {
+      // }
         lon = -74.009,
         lat = 40.70531
-      }
-
       // creates a map with default (bubble-wrap) style
-      var map = L.Mapzen.map('map');
+      var map = L.Mapzen.map('map', {
+        _debugTangram: true
+      });
 
       map.setView([lat, lon],13);
 
@@ -46,6 +46,13 @@
       // adds a search box to a map
       var geocoder = L.Mapzen.geocoder('search--NA8UXg');
       geocoder.addTo(map);
+
+      // allows for a URL hash to be created
+      L.Mapzen.hash({
+        map: map,
+        geocoder: geocoder
+      });
+
 
       // creates a Mapzen "bug" with header for Mapzen projects
       L.Mapzen.bug({
@@ -58,12 +65,6 @@
       var locator = L.Mapzen.locator();
       locator.setPosition('bottomright');
       locator.addTo(map);
-
-      // allows for a URL hash to be created
-      L.Mapzen.hash({
-        map: map,
-        geocoder: geocoder
-      });
 
       // adds a tangram event listener
       map.on('tangramloaded', function(e) {

--- a/examples/standalone-v1.0.html
+++ b/examples/standalone-v1.0.html
@@ -41,6 +41,10 @@
         scene: L.Mapzen.BasemapStyles.Tron
       });
 
+      L.Mapzen.hash({
+        map: map
+      });
+
       map.setView([lat, lon],13);
 
       map.zoomControl.setPosition('bottomright');
@@ -48,10 +52,6 @@
       var locator = L.Mapzen.locator();
       locator.setPosition('bottomright');
       locator.addTo(map);
-
-      L.Mapzen.hash({
-        map: map
-      });
 
     </script>
   </body>

--- a/examples/standalone.html
+++ b/examples/standalone.html
@@ -38,6 +38,11 @@
       map.setView([lat, lon],13);
       map.zoomControl.setPosition('bottomright');
 
+
+      L.Mapzen.hash({
+        map: map
+      });
+
       // Mapobox Geocoder
 
       var geocoder = L.mapbox.geocoder("mapbox.places",{
@@ -57,10 +62,6 @@
       var locator = L.Mapzen.locator();
       locator.setPosition('bottomright');
       locator.addTo(map);
-
-      L.Mapzen.hash({
-        map: map
-      });
 
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "leaflet": "global:L"
   },
   "dependencies": {
-    "leaflet": "^1.0.1",
+    "leaflet": "1.0.1",
     "leaflet-geocoder-mapzen": "^1.7.1",
     "mapzen-scarab": "git+https://github.com/mapzen/scarab.git"
   },

--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
     "leaflet": "global:L"
   },
   "dependencies": {
-    "leaflet": "^0.7.7",
-    "leaflet-geocoder-mapzen": "^1.6.2",
-    "mapzen-scarab": "git+https://github.com/mapzen/scarab.git"
+    "leaflet": "^1.0.1",
+    "leaflet-geocoder-mapzen": "^1.6.2"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.13.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "leaflet": "^1.0.1",
-    "leaflet-geocoder-mapzen": "^1.6.2"
+    "leaflet-geocoder-mapzen": "^1.6.2",
+    "mapzen-scarab": "git+https://github.com/mapzen/scarab.git"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.13.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "leaflet": "^1.0.1",
-    "leaflet-geocoder-mapzen": "^1.6.2",
+    "leaflet-geocoder-mapzen": "^1.7.1",
     "mapzen-scarab": "git+https://github.com/mapzen/scarab.git"
   },
   "devDependencies": {

--- a/src/js/components/hash.js
+++ b/src/js/components/hash.js
@@ -115,7 +115,8 @@ var Hash = L.Class.extend({
   },
 
   _roundZDown: function (z) {
-    return z.toFixed(4);
+    if (z % 1 === 0) return z;
+    else return z.toFixed(4);
   },
 
   _throttle: function (callback, limit) {

--- a/src/js/components/hash.js
+++ b/src/js/components/hash.js
@@ -36,7 +36,6 @@ var Hash = L.Class.extend({
       } else if (this._hashData.lat && this._hashData.lng && this._hashData.z) {
         // boolean changing is to prevent recursive hash change
         // Hash doesn't get updated while map is setting the view
-        console.log(this._hashData);
         this._changing = true;
         if (this._map) this._map.setView([this._hashData.lat, this._hashData.lng], this._hashData.z);
         this._changing = false;

--- a/src/js/components/hash.js
+++ b/src/js/components/hash.js
@@ -147,7 +147,6 @@ var Formatter = {
         var keyAndValue = valArrs[val].split('=');
         dObj[keyAndValue[0]] = keyAndValue[1];
       }
-
       return dObj;
     }
   },

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -70,7 +70,7 @@ var MapControl = L.Map.extend({
   },
 
   _disableZoomControl: function () {
-    if(this.options.zoomControl) {
+    if (this.options.zoomControl) {
       this.zoomControl._container.hidden = true;
     }
   }

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -11,7 +11,7 @@ var MapControl = L.Map.extend({
 
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
-    L.Map.prototype.options.zoomSnap = 0.01;
+    L.Map.prototype.options.zoomSnap = 0;
     var opts = L.extend({}, L.Map.prototype.options, options);
     L.Map.prototype.initialize.call(this, element, opts);
 

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -5,8 +5,8 @@ var MapControl = L.Map.extend({
   includes: L.Mixin.Events,
   options: {
     attribution: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors',
-    _useTangram: true,
-    _debugTangram: false
+    debugTangram: false,
+    _useTangram: true
   },
 
   // overriding Leaflet's map initializer
@@ -17,7 +17,7 @@ var MapControl = L.Map.extend({
 
     if (this.options._useTangram) {
       this._tangram = L.Mapzen._tangram({
-        _debug: this.options._debugTangram
+        debug: this.options.debugTangram
       });
 
       this._tangram.addTo(this);

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -11,7 +11,9 @@ var MapControl = L.Map.extend({
 
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
-    L.Map.prototype.initialize.call(this, element, L.extend({}, L.Map.prototype.options, options));
+    L.Map.prototype.options.zoomSnap = 0.01;
+    var opts = L.extend({}, L.Map.prototype.options, options);
+    L.Map.prototype.initialize.call(this, element, opts);
 
     if (this.options._useTangram) {
       this._tangram = L.Mapzen._tangram({

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -203,8 +203,6 @@ var Geocoder = L.Control.extend({
     };
 
     this.callPelias(url, params, 'search');
-
-    return 'yo';
   },
 
   autocomplete: throttle(function (input) {

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -203,6 +203,8 @@ var Geocoder = L.Control.extend({
     };
 
     this.callPelias(url, params, 'search');
+
+    return 'yo';
   },
 
   autocomplete: throttle(function (input) {

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -12,7 +12,7 @@ var TangramLayer = L.Class.extend({
     tangramURL: 'https://mapzen.com/tangram/0.10/tangram.min.js'
   },
   initialize: function (opts) {
-    if (opts._debug) this.options.tangramURL = 'https://mapzen.com/tangram/0.10/tangram.debug.js';
+    if (opts.debug) this.options.tangramURL = 'https://mapzen.com/tangram/0.10/tangram.debug.js';
     this.options = L.extend({}, opts, this.options);
 
     // Start importing script

--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -24,5 +24,5 @@ L.Mapzen = module.exports = {
 
 // Set Icon Path manually (Leaflet detects the path based on where Leaflet script is)
 // Leaflet 0.7 and < 1.0 handle image path differently
-if (parseFloat(L.version.substring(0,3)) < 1.0) L.Icon.Default.imagePath = 'https://mapzen.com/js/images';
+if (parseFloat(L.version.substring(0, 3)) < 1.0) L.Icon.Default.imagePath = 'https://mapzen.com/js/images';
 else L.Icon.Default.prototype.options.imagePath = 'https://mapzen.com/js/images/';

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -112,7 +112,7 @@ module.exports = function (config) {
         base: 'BrowserStack',
         device: 'iPhone 6S',
         os: 'ios',
-        os_version: '9.3'
+        os_version: '9.0'
       }
     },
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = function (config) {
 
     client: {
       mocha: {
-        timeout: 20000 // 20 seconds
+        timeout: 60000 // 60 seconds
       }
     },
     // preprocess matching files before serving them to the browser

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -95,7 +95,7 @@ module.exports = function (config) {
       accessKey: process.env.BROWSERSTACK_KEY
     },
     // Tweaks for Browserstack timeout
-    browserDisconnectTimeout: 20000, // default 2000
+    browserDisconnectTimeout: 60000, // default 2000
     browserDisconnectTolerance: 1, // default 0
     browserNoActivityTimeout: 4 * 60 * 1000, // default 10000,
     captureTimeout: 4 * 60 * 1000, // default 60000

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -116,6 +116,6 @@ module.exports = function (config) {
       }
     },
 
-    browsers: ['PhantomJS', 'bs_iphone6S', 'bs_ie_window']
+    browsers: ['PhantomJS', 'bs_ie_window']
   });
 };

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -35,18 +35,20 @@ describe('Map Hash Test', function () {
       var hash = L.Mapzen.hash({
         map: map
       });
-      var zoom = map.getZoom();
+      var zoom = hash._roundZDown(map.getZoom());
       var center = map.getCenter();
 
       var getPrecision = function (z) {
         return Math.max(0, Math.ceil(Math.log(z) / Math.LN2));
       };
-      var precision = getPrecision(zoom);
+
+      var precision = hash._precision(zoom);
 
       var hashLat = center.lat.toFixed(precision);
       var hashLng = center.lng.toFixed(precision);
       var hashVal = window.location.hash;
       hash._reset(); // For next test
+      console.log(hashVal);
       expect(hashVal).to.equal('#lat=' + hashLat + '&lng=' + hashLng + '&z=' + zoom);
     });
 

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -48,7 +48,7 @@ describe('Map Hash Test', function () {
       var hashLng = center.lng.toFixed(precision);
       var hashVal = window.location.hash;
       hash._reset(); // For next test
-      console.log(hashVal);
+
       expect(hashVal).to.equal('#lat=' + hashLat + '&lng=' + hashLng + '&z=' + zoom);
     });
 

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -22,13 +22,6 @@ describe('Map Hash Test', function () {
     el.parentNode.removeChild(el);
   })
 
-
-  // describe('Leaflet Versions', function () {
-  //   it('check which Leaflet version it is', function () {
-  //     expect(L.version).to.equal('0.7.7');
-  //   });
-  // });
-
   describe('Hash Working', function () {
     it('checks that hash for coord is working', function () {
       map.setView([51.505, -0.09], 13);

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -23,11 +23,11 @@ describe('Map Hash Test', function () {
   })
 
 
-  describe('Leaflet Versions', function () {
-    it('check which Leaflet version it is', function () {
-      expect(L.version).to.equal('0.7.7');
-    });
-  });
+  // describe('Leaflet Versions', function () {
+  //   it('check which Leaflet version it is', function () {
+  //     expect(L.version).to.equal('0.7.7');
+  //   });
+  // });
 
   describe('Hash Working', function () {
     it('checks that hash for coord is working', function () {

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -22,6 +22,13 @@ describe('Map Control Test', function () {
     el.parentNode.removeChild(el);
   })
 
+  describe('Leaflet Versions', function () {
+    it('check which Leaflet version it is', function () {
+      expect(L.version).to.equal('1.0.1');
+    });
+  });
+
+
   describe('Tangram layer check', function () {
     it('checks default style is set.', function (done) {
 


### PR DESCRIPTION
- closes #249 
- anchored Leaflet version v1.0.1 just in case. We will consider make this version number more generous (^) in future. For now, it will be better to pair with Leaflet version number we are sure that it works. 
- set `zoomSnap` option as zero in the initialization so Hash doesn't try to round up/down zoom level. 
- bumped up the test version number 
- made `_debugTangram` option to public (`debugTangram`)