### PR TITLE
add versioning section

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -17,7 +17,8 @@ To reference the mapzen.js cascading style sheet (CSS) and JavaScript file, add 
 
 ## Versioning with mapzen.js
 
-When a new version of mapzen.js is released, semantic versioning is used to describe the scope of code changes. It's recommended that you peg your development to a specific version of mapzen.js, instead of the latest version. Read through each version's [release notes on GitHub](https://github.com/mapzen/mapzen.js/releases) to learn more about a specific release.
+
+Semantic versioning is used for mapzen.js to allow you to choose a specific release to develop with, as well as describe the scope of code changes in a release. Versions follow a format of `X.Y.Z`, with a `MAJOR`.`MINOR`.`PATCH` version indicator. It's recommended that you peg your development to a specific version of mapzen.js, instead of the latest version. Read through each version's [release notes on GitHub](https://github.com/mapzen/mapzen.js/releases) to learn more about a specific release.
 
 ### Version components
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -15,6 +15,25 @@ To reference the mapzen.js cascading style sheet (CSS) and JavaScript file, add 
 <script src="https://mapzen.com/js/mapzen.min.js"></script>
 ```
 
+## Versioning with mapzen.js
+
+When a new version of mapzen.js is released, semantic versioning is used to describe the scope of code changes. It's recommended that you peg your development to a specific version of mapzen.js, instead of the latest version. Read through each version's [release notes on GitHub](https://github.com/mapzen/mapzen.js/releases) to learn more about a specific release.
+
+### Version components
+
+`MAJOR`.`MINOR`.`PATCH`, example: `0.0.0`
+
+- https://mapzen.com/js/mapzen.js (latest)
+- https://mapzen.com/js/0/mapzen.js (major)
+- https://mapzen.com/js/0.0/mapzen.js (minor)
+- https://mapzen.com/js/0.0.0/mapzen.js (patch)
+
+### Version parts:
+
+- **MAJOR** version **X** for incompatible API changes.
+- **MINOR** version **Y** when adding functionality in a backwards-compatible manner, and
+- **PATCH** version **Z** when fixing backwards-compatible bugs
+
 ## Using standalone version
 
 Currently, mapzen.js embeds [Leaflet 1.0](http://leafletjs.com/reference-1.0.0.html) in it. If you need to use your own version of Leaflet with mapzen.js, you can use standalone version which doesn't include Leaflet.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -17,8 +17,7 @@ To reference the mapzen.js cascading style sheet (CSS) and JavaScript file, add 
 
 ## Versioning with mapzen.js
 
-
-Semantic versioning is used for mapzen.js to allow you to choose a specific release to develop with, as well as describe the scope of code changes in a release. Versions follow a format of `X.Y.Z`, with a `MAJOR`.`MINOR`.`PATCH` version indicator. It's recommended that you peg your development to a specific version of mapzen.js, instead of the latest version. Read through each version's [release notes on GitHub](https://github.com/mapzen/mapzen.js/releases) to learn more about a specific release.
+Mapzen.js uses semantic versioning to allow you to choose a specific release to develop with, as well as describe the scope of code changes in a release. Versions follow a format of `X.Y.Z`, with a `MAJOR`.`MINOR`.`PATCH` version indicator. It's recommended that you peg your development to a specific version of mapzen.js, instead of the latest version. Read through each version's [release notes on GitHub](https://github.com/mapzen/mapzen.js/releases) to learn more about a specific release.
 
 ### Version components
 
@@ -28,12 +27,6 @@ Semantic versioning is used for mapzen.js to allow you to choose a specific rele
 - https://mapzen.com/js/0/mapzen.js (major)
 - https://mapzen.com/js/0.0/mapzen.js (minor)
 - https://mapzen.com/js/0.0.0/mapzen.js (patch)
-
-### Version parts:
-
-- **MAJOR** version **X** for incompatible API changes.
-- **MINOR** version **Y** when adding functionality in a backwards-compatible manner, and
-- **PATCH** version **Z** when fixing backwards-compatible bugs
 
 ## Using standalone version
 


### PR DESCRIPTION
To update with the new & improved README #299, I've updated the 'get-started.md' to show versioning recommendations #297.

This PR is still in progress and I'd love some discussion on:

- Describing version parts come straight from the Cartography Docs 'Versioning' page and could use some mapzen.js specific explanation.

- I like @migurski's use of the links to show the specific syntax of each type of version, but think it needs some explaining text?

- Should we still provide the latest code in the code bank in lines 7-16?