### PR TITLE
Set default UI positions

### DIFF
--- a/src/js/components/locator.js
+++ b/src/js/components/locator.js
@@ -545,6 +545,7 @@ module.exports = Locator;
 
 module.exports.locator = function () {
   var locator = new Locator({
+    position: 'bottomright',
     drawCircle: false,
     follow: false,
     showPopup: false,

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -30,6 +30,8 @@ var MapControl = L.Map.extend({
       });
     }
 
+    this._setDefaultUIPositions();
+
     // Adding Mapzen attribution to Leaflet
     if (this.attributionControl) {
       this.attributionControl.setPrefix('');
@@ -74,6 +76,12 @@ var MapControl = L.Map.extend({
   _disableZoomControl: function () {
     if (this.options.zoomControl) {
       this.zoomControl._container.hidden = true;
+    }
+  },
+
+  _setDefaultUIPositions: function () {
+    if (this.options.zoomControl) {
+      this.zoomControl.setPosition('bottomright');
     }
   }
 });

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -31,15 +31,7 @@ var MapControl = L.Map.extend({
     }
 
     this._setDefaultUIPositions();
-
-    // Adding Mapzen attribution to Leaflet
-    if (this.attributionControl) {
-      this.attributionControl.setPrefix('');
-      var tempAttr = this.options.attributionText || this.options.attribution;
-      this.attributionControl.addAttribution(tempAttr);
-      this.attributionControl.addAttribution('<a href="http://leafletjs.com/">Leaflet</a>');
-    }
-
+    this._addAttribution();
     this._checkConditions(false);
   },
 
@@ -82,6 +74,16 @@ var MapControl = L.Map.extend({
   _setDefaultUIPositions: function () {
     if (this.options.zoomControl) {
       this.zoomControl.setPosition('bottomright');
+    }
+  },
+
+  _addAttribution: function () {
+    // Adding Mapzen attribution to Leaflet
+    if (this.attributionControl) {
+      this.attributionControl.setPrefix('');
+      var tempAttr = this.options.attributionText || this.options.attribution;
+      this.attributionControl.addAttribution(tempAttr);
+      this.attributionControl.addAttribution('<a href="http://leafletjs.com/">Leaflet</a>');
     }
   }
 });


### PR DESCRIPTION
Adding default positions for our UI elements in mapzen.js to align with most of our demos.  Users can still override the positioning of each element, but this change will make for better out-of-the-box mapzen.js demos.

- Set default position of locator to bottom right
- Set default position of zoomControl to bottom right
- Leave geocoder position at top left
- Leave Mapzen scarab at top center

Let me know if you have a strong preference for a different set of defaults.
cc/ @hanbyul-here @migurski @souperneon @meetar @burritojustice 