### PR TITLE
Add test examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,11 +1,9 @@
-<!-- This example assumes you have local version of mapzen.js in dist folder -->
-<!-- Please look at BUILD.md to build local version of mapzen.js -->
 <!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="stylesheet" href="../dist/mapzen.css">
+    <link rel="stylesheet" href="https://mapzen.com/js/mapzen.css">
     <style>
       html, body {
         width: 100%;
@@ -21,7 +19,7 @@
   </head>
   <body>
     <div id="map"></div>
-    <script src="../dist/mapzen.js"></script>
+    <script src="https://mapzen.com/js/mapzen.min.js"></script>
     <script>
 
       var lat, lon;

--- a/examples/standalone-v1.0.html
+++ b/examples/standalone-v1.0.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.1/dist/leaflet.css" />
-    <link rel="stylesheet" href="../dist/mapzen.standalone.css">
+    <link rel="stylesheet" href="https://mapzen.com/js/mapzen.standalone.css">
     <style>
       html, body {
         width: 100%;
@@ -22,7 +22,7 @@
     <div id="map"></div>
     <script src='https://geoiplookup.wikimedia.org/'></script>
     <script src="http://cdn.leafletjs.com/leaflet/v1.0.1/leaflet.js"></script>
-    <script src="../dist/mapzen.standalone.min.js"></script>
+    <script src="https://mapzen.com/js/mapzen.standalone.min.js"></script>
     <script>
 
       // when GeoIP is available, set the map's initial view to detected coords.

--- a/examples/standalone.html
+++ b/examples/standalone.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link rel="stylesheet" href="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.css" />
     <link href='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.css' rel='stylesheet' />
-    <link rel="stylesheet" href="../dist/mapzen.standalone.css">
+    <link rel="stylesheet" href="https://mapzen.com/js/mapzen.standalone.css">
     <style>
       html, body {
         width: 100%;
@@ -23,7 +23,7 @@
     <div id="map"></div>
     <script src="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.js"></script>
     <script src='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.standalone.js'></script>
-    <script src="../dist/mapzen.standalone.min.js"></script>
+    <script src="https://mapzen.com/js/mapzen.standalone.min.js"></script>
     <script>
 
       // when GeoIP is available, set the map's initial view to detected coords.

--- a/test/examples/all-defaults.html
+++ b/test/examples/all-defaults.html
@@ -1,0 +1,72 @@
+<!-- This example assumes you have local version of mapzen.js in dist folder -->
+<!-- Please look at BUILD.md to build local version of mapzen.js -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="../../dist/mapzen.css">
+    <style>
+      html, body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+      #map {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src="../../dist/mapzen.min.js"></script>
+    <script>
+      var start = performance.now();
+      console.log('TIMER: starting timer');
+
+      var lon = -74.009,
+          lat = 40.70531;
+
+      // Default map (Bubble Wrap)
+      var map = L.Mapzen.map('map', {
+        debugTangram: true
+      });
+      map.setView([lat, lon],13);
+
+      // Add search box
+      var geocoder = L.Mapzen.geocoder('search--NA8UXg');
+      geocoder.addTo(map);
+
+      // Add URL hash
+      L.Mapzen.hash({
+        map: map,
+        geocoder: geocoder
+      });
+
+      // Add Mapzen "bug" with header for Mapzen projects
+      L.Mapzen.bug({
+        name: 'Web Map',
+        tweet: '@mapzen',
+        repo: 'https://github.com/mapzen/web-map',
+        mapID: 'map'});
+
+      // Add locator button
+      var locator = L.Mapzen.locator();
+      locator.addTo(map);
+
+      // Listen for Tangram loaded event
+      map.on('tangramloaded', function(e) {
+        var stop = performance.now();
+        var seconds = (stop - start)/1000;
+
+        console.log('Loaded Leaflet version ', L.version);
+        console.log('Loaded Tangram version', e.tangramVersion);
+
+        console.log('TIMER: ', seconds, ' seconds to tangramloaded event');
+      });
+
+    </script>
+  </body>
+</html>

--- a/test/examples/eraser-map.html
+++ b/test/examples/eraser-map.html
@@ -1,0 +1,56 @@
+<!-- This example assumes you have local version of mapzen.js in dist folder -->
+<!-- Please look at BUILD.md to build local version of mapzen.js -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="../../dist/mapzen.css">
+    <link rel="stylesheet" href="https://erasermap.com/map/erasermap.css">
+
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src='https://geoiplookup.wikimedia.org/'></script>
+    <script src="../../dist/mapzen.min.js"></script>
+    <script>
+
+      // when GeoIP is available, set the map's initial view to detected coords.
+      var lat, lon;
+
+      if (typeof Geo === 'object') {
+        lon = Geo.lon
+        lat = Geo.lat
+      } else {
+        lon = -74.009
+        lat = 40.70531
+      }
+
+      var map = L.Mapzen.map('map');
+      map.setView([lat, lon],13);
+
+
+      map.zoomControl.setPosition('bottomright');
+
+      var geocoder = L.Mapzen.geocoder('search--NA8UXg');
+      geocoder.addTo(map);
+
+      L.Mapzen.bug({
+        name: 'Web Map',
+        link: 'https://erasermap.com/map',
+        tweet: '@mapzen',
+        repo: 'https://github.com/mapzen/eraser-map-website'
+        });
+
+      var locator = L.Mapzen.locator();
+      locator.setPosition('bottomright');
+      locator.addTo(map);
+
+      L.Mapzen.hash({
+        map: map,
+        geocoder:geocoder
+      });
+
+    </script>
+  </body>
+</html>

--- a/test/examples/house-style-switcher-embed.html
+++ b/test/examples/house-style-switcher-embed.html
@@ -1,0 +1,116 @@
+<!-- This example assumes you have local version of mapzen.js in dist folder -->
+<!-- Please look at BUILD.md to build local version of mapzen.js -->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <title>Mapzen House Styles</title>
+  <link rel='stylesheet' href='https://mapzen.com/common/styleguide/styles/blog.css' type='text/css'>
+  <link rel="stylesheet" href="../../dist/mapzen.css">
+  <style>
+    html, body {
+      width: 100%;
+      height: 100%;
+      padding: 0;
+      margin: 0;
+    }
+    #map {
+      width: 100%;
+      height: calc(100% - 60px);
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <div id='map'></div>
+
+  <div class="demo-controls" id="demo-controls">
+    <div class="demo-control-previous"><i class="fa fa-fw fa-angle-left"></i></div>
+    <ul class="demo-control-list">
+    </ul>
+    <div class="demo-control-next"><i class="fa fa-fw fa-angle-right"></i></div>
+  </div>
+  <script src="../../dist/mapzen.min.js"></script>
+  <script src='https://mapzen.com/resources/projects/demo-switcher.js'></script>
+
+  <script>
+  (function () {
+    var spinner,
+        LoadingSpinner = L.Control.extend({
+          options: { position: 'bottomleft' },
+          onAdd: function (map) {
+            if(!spinner)
+            {
+              spinner = L.DomUtil.create('div');
+              spinner.appendChild(L.DomUtil.create('div', 'loading-spinner-02'));
+              spinner.appendChild(document.createTextNode('Loading new map style…'));
+              spinner.style.borderRadius = '2px';
+              spinner.style.backgroundColor = 'white';
+              spinner.style.lineHeight = '26px';
+              spinner.style.paddingRight = '7px';
+              spinner.firstChild.style.float = 'left';
+            }
+
+            spinner.style.visibility = 'hidden';
+            return spinner;
+          }
+        });
+
+    var map = L.Mapzen.map('map');
+    var tangramLayer;
+    map.setView([37.66347, -122.39588], 15);
+
+    map.addControl(new LoadingSpinner());
+
+    L.Mapzen.hash({map: map});
+    L.Mapzen.locator().addTo(map);
+
+    L.Mapzen.bug({
+      name: 'Mapzen House Styles',
+      link: '/products/maps/',
+      tweet: '@mapzen',
+      repo: 'https://github.com/tangrams/?utf8=✓&query=style'
+    });
+
+    function inIframe () {
+      try {
+        return window.self !== window.top;
+      } catch (e) {
+        return true;
+      }
+    }
+
+    if (!inIframe()) {
+      L.Mapzen.geocoder('search-Y2Sr2RD').addTo(map);
+    }
+
+    map.on('tangramloaded', function(e) {
+      tangramLayer = e.tangramLayer;
+    });
+
+    var demo_sources = [
+        { title: 'Bubble Wrap', scene: L.Mapzen.BasemapStyles.BubbleWrap },
+        { title: 'Refill', scene: L.Mapzen.BasemapStyles.RefillMoreLabels },
+        { title: 'Walkabout', scene: L.Mapzen.BasemapStyles.WalkaboutMoreLabels },
+        { title: 'Tron', scene: L.Mapzen.BasemapStyles.TronMoreLabels },
+        { title: 'Cinnabar', scene: L.Mapzen.BasemapStyles.CinnabarMoreLabels },
+        { title: 'Zinc', scene: L.Mapzen.BasemapStyles.ZincMoreLabels }
+      ];
+
+    new DemoSwitcher({
+      sources: demo_sources,
+      onClick: function (source) {
+        spinner.style.visibility = 'visible';
+        // Reload it.
+        if(tangramLayer) {
+          tangramLayer.scene.load(source.scene).then(
+            function() { spinner.style.visibility = 'hidden' })
+        }
+      }
+    })
+  })();
+  </script>
+</body>
+</html>

--- a/test/examples/isochrone-map.html
+++ b/test/examples/isochrone-map.html
@@ -1,0 +1,262 @@
+<!-- This example assumes you have local version of mapzen.js in dist folder -->
+<!-- Please look at BUILD.md to build local version of mapzen.js -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Isochrone service demo</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../../dist/mapzen.css">
+    <script src="../../dist/mapzen.min.js"></script>
+    <style>
+      html,body{margin: 0; padding: 0}
+      #map {
+        height: 100%;
+        width: 100%;
+        position: absolute;
+      }
+      .isochrone-control {
+        background: rgba(255, 255, 255, 0.85);
+        padding: 5px 10px;
+        width: 230px; /*width: 120px;*/
+        border-radius: 5px;
+      }
+      .isochrone-control div {
+        margin: 2px 0;
+      }
+      .isochrone-control h3 {
+        margin: 5px 2px 0 2px;
+      }
+      .isochrone-control ul {
+        padding: 0;
+        margin: 0;
+      }
+      .isochrone-control li {
+        list-style: none;
+        width: 110px;
+        display: inline-block;
+      }
+      .isochrone-control .emoji {
+        width: 30px;
+        display: inline-block;
+        text-align: center;
+      }
+      .isochrone-control .legend-box {
+        display: inline-block;
+        width: 20px;
+        height: 10px;
+      }
+      .isochrone-control .legend-box.first {
+        background-color: #40cc40;
+      }
+      .isochrone-control .legend-box.second {
+        background-color: #9fbf40;
+      }
+      .isochrone-control .legend-box.third {
+        background-color: #bf8f40;
+      }
+      .isochrone-control .legend-box.fourth {
+        background-color: #bf4040;
+      }
+      .isochrone-control .legend-label {
+        padding-left: 5px;
+      }
+
+  </style>
+  </head>
+<body>
+  <div id="map"></div>
+
+  <script>
+    var scene, mode, time;
+
+    // Set default lat / lng
+    var lat = 49.282;
+    var lng = -123.1207;
+
+    var tooltip = L.tooltip();
+
+    var map = L.Mapzen.map('map', {
+      center: [lat, lng],
+      zoom: 12,
+      debugTangram: true,
+      scene: 'resources/isochrone-map.yaml'
+    });
+
+    // Move zoom control to the top right corner of the map
+    map.zoomControl.setPosition('topright');
+
+    // Mapzen Search box (replace key with your own)
+    // To generate your own key, go to https://mapzen.com/developers/
+    var geocoder = L.Mapzen.geocoder('mapzen-JA21Wes');
+    geocoder.addTo(map);
+  
+    // add lat/lon hash 
+    L.Mapzen.hash({
+      map: map
+    });
+
+    var defaults = {
+      pedestrian: {
+        label: 'walking',
+        times: [5,10,15,20],
+        emoji: '🚶'
+      },
+      bicycle: {
+        label: 'bike',
+        times: [15,30,45,60],
+        emoji: '🚴'
+      },
+      auto: {
+        label: 'car',
+        times: [15,30,60,90],
+        emoji: '🚗'
+      },
+      multimodal: {
+        label: 'transit',
+        times: [30,60,90,120],
+        emoji: '🚌'
+      }
+    };
+  
+
+    // Custom Leaflet Control - isochrone parameters
+    var IsochroneControl = L.Control.extend({
+      options: {
+          position: 'bottomleft'
+      },
+
+      onAdd: function (map) {
+          var container = L.DomUtil.create('div', 'isochrone-control');
+          container.innerHTML = '<div>'
+            + '  <h3>Travel by:</h3>' 
+            + '  <ul id="travel-modes">'
+            + '    <li><input type="radio" name="modes" id="pedestrian" value="pedestrian" /><span class="emoji">' + defaults['pedestrian'].emoji + '</span><span class="label">' + defaults['pedestrian'].label + '</span></li>'
+            + '    <li><input type="radio" name="modes" id="bicycle" value="bicycle" checked="checked" /><span class="emoji">' + defaults['bicycle'].emoji + '</span><span class="label">' + defaults['bicycle'].label + '</span></li>' 
+            + '    <li><input type="radio" name="modes" id="auto" value="auto" /><span class="emoji">' + defaults['auto'].emoji + '</span><span class="label">' + defaults['auto'].label + '</span></li>' 
+            + '    <li><input type="radio" name="modes" id="multimodal" value="multimodal" /><span class="emoji">' + defaults['multimodal'].emoji + '</span><span class="label">' + defaults['multimodal'].label + '</span></li>'
+            + '  </ul><br>'
+            + '  <h3>Estimated times:</h3>'
+            + '  <div id="travel-times">'
+            + '     <i>Click on the map to set starting point</i>'
+            + '  </div>'
+            + '</div>';
+
+          L.DomEvent.on(container, "click", this.onClick);
+          return container;
+      },
+
+      update: function (time) {
+        L.DomUtil.get('travel-times').innerHTML = (time
+            ? '<ul>'
+              + ' <li><span class="legend-box first"></span><span class="legend-label">' + time[0] + ' minutes</span></li>'
+              + ' <li><span class="legend-box second"></span><span class="legend-label">' + time[1] + ' minutes</span></li>'
+              + ' <li><span class="legend-box third"></span><span class="legend-label">' + time[2] + ' minutes</span></li>'
+              + ' <li><span class="legend-box fourth"></span><span class="legend-label">' + time[3] + ' minutes</span></li>'
+              + '</ul>'
+            : '<i>Click on the map to set starting point</i>');
+      },
+
+      onClick: function (e) {
+        // stop propagation to avoid triggering onMapClick
+        e.stopPropagation();
+        updateMap();
+      }
+    });
+    var isochroneControl = new IsochroneControl();
+    map.addControl(isochroneControl);
+
+
+    // map click handler
+    function onMapClick(e) {
+      // Update the global lat / lng
+      lat = e.leaflet_event.latlng.lat;
+      lng = e.leaflet_event.latlng.lng;
+
+      updateMap();
+    }
+
+    function updateMap() {
+      reloadIsochrone();
+      reloadEmoji();
+      isochroneControl.update(time);
+    }
+
+    function reloadIsochrone() {
+      // get mode from radio input
+      mode = document.querySelector('input[name = "modes"]:checked').value;
+      time = defaults[mode].times;
+
+      var url = 'https://matrix.mapzen.com/isochrone?json=';
+      var json = {
+        locations: [{"lat":lat, "lon":lng}],
+        costing: mode,
+        contours: [{"time":time[0]},{"time":time[1]},{"time":time[2]},{"time":time[3]}],
+        polygons: true,
+        denoise: 0.5,
+        generalize: 150
+      };
+      url += escape(JSON.stringify(json));
+      url+= '&api_key=mapzen-c4C1Lbb';
+
+      scene.setDataSource('isochrone_live', { type: 'GeoJSON', url: url });
+    }
+
+    function reloadEmoji() {
+      var emoji = defaults[mode].emoji;
+      
+      // define GeoJSON point for emoji label
+      var emojiJSON = {
+        "type": "FeatureCollection",
+        "features": [
+        {
+          "type": "Feature",
+          "properties": {
+            "name": emoji
+          },
+          "geometry": {
+          "type": "Point",
+              "coordinates": [lng, lat]
+            }
+          }
+        ]
+      };
+
+      scene.config.layers.emoji_label.visible = true;
+      scene.setDataSource('emoji_marker', { type: 'GeoJSON', data: emojiJSON });
+    }
+
+    function onMapHover(e) {
+      if (e.feature && e.feature.source_name == 'isochrone_live') {
+        document.getElementById('map').style.cursor = 'pointer';
+
+        var content = 'Less than <b>' + e.feature.properties.contour + ' minutes</b> away by ' + defaults[mode].label;
+        updateTooltip(e.leaflet_event.latlng, content);
+      } else {
+        tooltip.remove();
+        document.getElementById('map').style.cursor = '';
+      }
+    }
+
+    function updateTooltip(latlng, content) {
+      tooltip.setLatLng(latlng);
+      tooltip.setContent(content);
+
+      if (!tooltip.isOpen()) {
+        tooltip.addTo(map);
+      }
+    }
+    
+    // Add a Tangram event listener
+    map.on('tangramloaded', function(e) {
+      var tangramLayer = e.tangramLayer;
+      scene = tangramLayer.scene;
+      
+      tangramLayer.setSelectionEvents({
+         click: onMapClick,
+         hover: onMapHover
+      });
+    });
+
+  </script>
+</body>
+</html>

--- a/test/examples/resources/isochrone-map.yaml
+++ b/test/examples/resources/isochrone-map.yaml
@@ -1,0 +1,53 @@
+# Author @burritojustice @rhonda_friberg - 2016
+
+import:
+    - https://tangrams.github.io/blocks/global.yaml
+    - https://mapzen.com/carto/refill-style/refill-style.yaml
+
+sources:
+
+    isochrone_live:
+        type: GeoJSON
+        url: 'https://matrix.mapzen.com/isochrone?json={"locations":[{"lat":53.5421,"lon":-113.4860}],"costing":"pedestrian","contours":[{"time":15},{"time":30},{"time":60},{"time":120}],"polygons":true,"denoise":0.2,"generalize":150}'
+        url_params:
+            api_key: mapzen-JA21Wes # (be sure to add your API key to pull in polygons from the server https://mapzen.com/developers)
+
+layers:
+
+    roads:
+        data: { source: mapzen, layer: roads }
+        filter: { not: { kind: rail } }
+        draw:
+            lines:
+                interactive: false
+                #color: black
+                width: 1px
+                order: global.feature_order
+                # but give them all the same outline
+                outline:
+                    style: _outline
+
+    isochrone_polygons:
+        data: { source: isochrone_live }
+        draw:
+            polygons:
+                interactive: true
+                order: |
+                    function() {
+                        return 100 - ((feature.contour/120) * 10) ;
+                        }
+                color: |
+                    function() {
+                        return feature.fill;
+                        }
+
+    emoji_label:
+        data: { source: emoji_marker }
+        visible: false
+        draw:
+            text:
+                collide: false
+                font:
+                    size: [[13, 30px], [20, 44px]]
+
+

--- a/test/examples/standalone-with-Leaflet-v0.7.html
+++ b/test/examples/standalone-with-Leaflet-v0.7.html
@@ -1,0 +1,76 @@
+<!-- This example assumes you have local version of mapzen.js in dist folder -->
+<!-- Please look at BUILD.md to build local version of mapzen.js -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.css" />
+    <link rel="stylesheet" href="../../dist/mapzen.standalone.css">
+    <style>
+      html, body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+      #map {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.js"></script>
+    <script src="../../dist/mapzen.standalone.min.js"></script>
+    <script>
+      var start = performance.now();
+      console.log('TIMER: starting timer');
+
+      var lat = 40.70531;
+      var lon = -74.009;
+
+      var map = L.Mapzen.map('map',{
+        scene: L.Mapzen.BasemapStyles.Refill,
+        debugTangram: true
+      });
+
+      map.setView([lat, lon],13);
+      map.zoomControl.setPosition('bottomright');
+
+      // Add search box
+      var geocoder = L.Mapzen.geocoder('search--NA8UXg');
+      geocoder.addTo(map);
+
+      // Add URL hash
+      L.Mapzen.hash({
+        map: map,
+        geocoder: geocoder
+      });
+
+      // Add Mapzen "bug" with header for Mapzen projects
+      L.Mapzen.bug({
+        name: 'Web Map',
+        tweet: '@mapzen',
+        repo: 'https://github.com/mapzen/web-map',
+        mapID: 'map'});
+
+      // Add locator button
+      var locator = L.Mapzen.locator();
+      locator.setPosition('bottomright');
+      locator.addTo(map);
+
+      // Listen for Tangram loaded event
+      map.on('tangramloaded', function(e) {
+        var stop = performance.now();
+        var seconds = (stop - start)/1000;
+
+        console.log('Loaded Leaflet version', L.version);
+        console.log('Loaded Tangram version', e.tangramVersion);
+
+        console.log('TIMER: ', seconds, ' seconds to tangramloaded event');
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Related to issue #305 - add set of examples to the test directory to enable faster testing of new mapzen.js builds (prior to release).

So far, the following examples have been included:
- *all-defaults.html*  - showing all mapzen.js defaults
- *standalone-with-Leaflet-v0.7.html* - standalone version using Leaflet v0.7
- *eraser-map.html* - copy/paste of erasermap.com/map
- *isochrone-map.html* - demo using isochrone service; dynamic layer updates via Tangram
- *house-style-switcher-embed.html* - copy/paste of the house style switcher we use on the blog

@hanbyul-here @migurski - are there other demos you can think of that would demonstrate a wide range of mapzen.js / Tangram / search capabilities?

