### PR TITLE
added search component behavior without ui

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -11,7 +11,9 @@ In this code, you are passing one parameter to the search, which is the API key 
 
 With a key, you have the full [Mapzen Search rate limits](https://mapzen.com/documentation/overview/#rate-limits) available to you. If you do not provide a valid API key, the number of queries you can perform are reduced greatly.
 
-## Control the search query behavior
+### Options
+
+#### Control the search query behavior
 
 These options affect the behavior of Mapzen Search itself.
 
@@ -23,7 +25,7 @@ These options affect the behavior of Mapzen Search itself.
 `layers` | String or Array | `null` | Filters results by layers ([documentation](https://mapzen.com/documentation/search/search/#filter-by-data-type)). If left blank, results will come from all available layers.
 `params` | Object | `null` | An object of key-value pairs which will be serialized into query parameters that will be passed to the Mapzen Search API. This allows custom queries that are not already supported by the convenience options listed above. Note that in case of conflicting parameters, this option takes precedence. All supplied parameters are passed through; this library doesn't know which are valid parameters and which are not.
 
-## Set the search appearance and interaction behavior
+#### Set the search appearance and interaction behavior
 
 These options affect the appearance and interaction behavior of the geocoder.
 
@@ -41,3 +43,13 @@ These options affect the appearance and interaction behavior of the geocoder.
 `markers` | [Leaflet Marker options object](http://leafletjs.com/reference.html#marker-options) or Boolean | `true` | If `true`, search results drops Leaflet's default blue markers onto the map. You may customize this marker's appearance and behavior using Leaflet [marker options](http://leafletjs.com/reference.html#marker-options).
 `fullWidth` | Integer or Boolean | `650` | If `true`, the input box will expand to take up the full width of the map container. If an integer breakpoint is provided, the full width applies only if the map container width is below this breakpoint.
 `place` | Boolean | `false` | If `true`, selected results will make a request to the service [`/place` endpoint](https://mapzen.com/documentation/search/place/). If `false`, this is disabled. The geocoder does not handle responses to `/place`; you will need to do handle it yourself in the `results` event listener.
+
+
+### Methods
+
+These methods work without UI component attached to the map.
+
+| Option  | Return | Description                      |
+|---------|---------|----------------------------------|
+`getSearchResult (<String>input, <function> callback)` | null | executes `callback(err, result)` with the search result from `input`. `result` is in [GeoJson format](https://search.mapzen.com/v1/search?text=yMcA). |
+`getAutocompleteResult(<String>input, <function> callback)` | null |  executes `callback(err, result)` with the autocomplete result from `input`.  `result` is in [GeoJson format](https://search.mapzen.com/v1/autocomplete?text=yMcA)|

--- a/docs/search.md
+++ b/docs/search.md
@@ -47,7 +47,7 @@ These options affect the appearance and interaction behavior of the geocoder.
 
 ### Methods
 
-These methods work without UI component attached to the map.
+If you want to implement your own search UI, or want to use search result without built-in UI component, you can use these methods.
 
 | Option  | Return | Description                      |
 |---------|---------|----------------------------------|

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -925,7 +925,24 @@ var Geocoder = L.Control.extend({
       }
     }
     previousWidth = width;
+  },
+
+  getSearchResult: function (input, callback) {
+    var param = {
+      text: input
+    };
+    var params = this.getParams(param);
+    AJAX.request(this.options.url + '/search', params, callback);
+  },
+
+  getAutoCompleteResult: function (input, callback) {
+    var param = {
+      text: input
+    };
+    var params = this.getParams(param);
+    AJAX.request(this.options.url + '/autocomplete', params, callback);
   }
+
 });
 
 /*


### PR DESCRIPTION
- added `getSearchResult(inputText, callback)` and `getAutocompleteResult(inputText, callback)` 
- I added how to used this `examples/index.html`. This examples logs the result. I wonder there is any better way to do this. (or maybe putting this in example folder is not necessary?) 