### PR TITLE
separated apikey

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -56,7 +56,9 @@ The `scene: L.Mapzen.BasemapStyles.Refill` line sets the style used for the map.
 
 ## API Key
 
-If you are planning to use Mapzen Search or Turn-by-turn service through mapzen.js, you can set up api key to use once through `L.Mapzen.apikey`. You can get your free api key through [Mapzen developer portal](https://mapzen.com/developers). We recommend you to put api key declaration ahead of other syntax.
+If you are planning to use Mapzen Search or Turn-by-turn service through mapzen.js, you can set up api key to use once through `L.Mapzen.apikey`. You can get your free api key through [Mapzen developer portal](https://mapzen.com/developers).
+
+Define your API key before adding other Mapzen components by setting:
 
 
 ```javascript

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,7 +13,9 @@ mapzen.js is an open-source JavaScript SDK and an extension of [Leaflet](http://
 | `scene` | String | `L.Mapzen.BasemapStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.BasemapStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
 | `fallbackTile` | [L.TileLayer](http://leafletjs.com/reference.html#tilelayer) | `L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {})` | TileLayer to fall back when WebGL is not available. |
 | `attribution` | String | `<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors` | Attribution data  in a small text box.`Leaflet` attribution is always there; attribution from this option is placed before `Leaflet` attribution.|
+| `apiKey`| string | null | Mapzen Api Key to be used for the components attached to the map.|
 | `debugTangram`| Boolean | `false` | Whether to load debug (not minified) version of Tangram or not.|
+
 
 
 ### Events
@@ -52,6 +54,14 @@ The `center:` parameter sets the center point of the map, in decimal degrees. Th
 
 The `scene: L.Mapzen.BasemapStyles.Refill` line sets the style used for the map. In this case, it is Mapzen's Refill style which provides a high contrast, black & white basemap useful for data visualization.
 
+## API Key
+
+If you are planning to use Mapzen Search or Turn-by-turn service through mapzen.js, you can set up api key to use once through `L.Mapzen.apikey`. You can get your free api key through [Mapzen developer portal](https://mapzen.com/developers). We recommend you to put api key declaration ahead of other syntax.
+
+
+```javascript
+L.Mapzen.apiKey = 'your-api-key';
+```
 
 ## Basemap styles
 

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -6,12 +6,12 @@ var MapControl = L.Map.extend({
   options: {
     attribution: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors',
     debugTangram: false,
+    zoomSnap: 0,
     _useTangram: true
   },
 
   // overriding Leaflet's map initializer
   initialize: function (element, options) {
-    L.Map.prototype.options.zoomSnap = 0;
     var opts = L.extend({}, L.Map.prototype.options, options);
     L.Map.prototype.initialize.call(this, element, opts);
 
@@ -31,9 +31,22 @@ var MapControl = L.Map.extend({
       });
     }
 
+    this._setupConfig(opts);
     this._setDefaultUIPositions();
     this._addAttribution();
     this._checkConditions(false);
+  },
+
+  _setupConfig: function (opts) {
+    // If the key is passed through map initialization
+    if (opts.apiKey) {
+      this.apiKey = opts.apiKey;
+      // When there is no L.Mapzen.apiKey yet, map one takes over.
+      if (!L.Mapzen.apiKey) L.Mapzen.apiKey = opts.apiKey;
+    // If the key is not passed through the map, but when there is a global one.
+    } else if (L.Mapzen.apiKey) {
+      this.apiKey = L.Mapzen.apiKey;
+    }
   },
 
   _checkConditions: function (force) {

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -598,7 +598,6 @@ var Geocoder = L.Control.extend({
   },
 
   onAdd: function (map) {
-    // 
     if (!this.apiKey && map.apiKey) this.apiKey = map.apiKey;
 
     var container = L.DomUtil.create('div',

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -53,7 +53,9 @@ var Geocoder = L.Control.extend({
     // first parameter is actually the options
     if (typeof apiKey === 'object' && !!apiKey) {
       options = apiKey;
+      if (L.Mapzen.apiKey) this.apiKey = L.Mapzen.apiKey;
     } else {
+      // If user specified the key to use
       this.apiKey = apiKey;
     }
 
@@ -596,6 +598,9 @@ var Geocoder = L.Control.extend({
   },
 
   onAdd: function (map) {
+
+    if (!this.apiKey) this.apiKey = map.apiKey;
+
     var container = L.DomUtil.create('div',
         'leaflet-pelias-control leaflet-bar leaflet-control');
 

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -598,8 +598,8 @@ var Geocoder = L.Control.extend({
   },
 
   onAdd: function (map) {
-
-    if (!this.apiKey) this.apiKey = map.apiKey;
+    // 
+    if (!this.apiKey && map.apiKey) this.apiKey = map.apiKey;
 
     var container = L.DomUtil.create('div',
         'leaflet-pelias-control leaflet-bar leaflet-control');

--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -19,7 +19,6 @@ L.Mapzen = module.exports = {
   hash: Hash.hash,
   HouseStyles: BasemapStyles,
   BasemapStyles: BasemapStyles,
-  apiKey: null,
   _tangram: TangramLayer.tangramLayer
 };
 

--- a/src/js/mapzen.js
+++ b/src/js/mapzen.js
@@ -19,6 +19,7 @@ L.Mapzen = module.exports = {
   hash: Hash.hash,
   HouseStyles: BasemapStyles,
   BasemapStyles: BasemapStyles,
+  apiKey: null,
   _tangram: TangramLayer.tangramLayer
 };
 

--- a/test/examples/all-defaults.html
+++ b/test/examples/all-defaults.html
@@ -17,11 +17,16 @@
         width: 100%;
         height: 100%;
       }
+      #map2 {
+        width: 100%;
+        height: 200px;
+      }
     </style>
   </head>
   <body>
     <div id="map"></div>
-    <script src="../../dist/mapzen.min.js"></script>
+    <div id="map2"></div>
+    <script src="../../dist/mapzen.js"></script>
     <script>
       var start = performance.now();
       console.log('TIMER: starting timer');
@@ -30,13 +35,17 @@
           lat = 40.70531;
 
       // Default map (Bubble Wrap)
+      L.Mapzen.apiKey = 'search--NA8UXg';
+
       var map = L.Mapzen.map('map', {
         debugTangram: true
       });
+            // Default map (Bubble Wrap)
+
       map.setView([lat, lon],13);
 
       // Add search box
-      var geocoder = L.Mapzen.geocoder('search--NA8UXg');
+      var geocoder = L.Mapzen.geocoder();
       geocoder.addTo(map);
 
       // Add URL hash

--- a/test/examples/all-defaults.html
+++ b/test/examples/all-defaults.html
@@ -17,15 +17,10 @@
         width: 100%;
         height: 100%;
       }
-      #map2 {
-        width: 100%;
-        height: 200px;
-      }
     </style>
   </head>
   <body>
     <div id="map"></div>
-    <div id="map2"></div>
     <script src="../../dist/mapzen.js"></script>
     <script>
       var start = performance.now();


### PR DESCRIPTION
- made `L.Mapzen.apiKey` to save apikey, so a user can set an apiKey in this way.
```
L.Mapzen.apiKey = 'your-api-key'
```
- the apiKey can also be passed as an option when the map is initialized, if there is not global apikey yet, this one will become a global one.
ex.
```
L.Mapzen.map('map',{
apKey: 'your-api-key;
});
```

- the apiKey can be passed through the component too (if the user wants to use separate key for the component, this will be useful), but when the key is not passed to the component, it will grab global one or share one from the map when the component is added to the map. This doesn't take over global one. (I wonder I should make component one to take over global one? 🤔  any thought? @rfriberg ?) 

```
L.Mapzen.geocoder('your-api-key');
```

@kkowalsky @rmglennon fyi, we are trying to save apikey as a global variable, so user has to pass the key only one time. All things will be backward compatible until official release (1.0.0), but we probably will change basic example, default way of using apikey.
