### PR TITLE
bumped up to leaflet 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "leaflet": "global:L"
   },
   "dependencies": {
-    "leaflet": "1.0.1",
+    "leaflet": "1.0.2",
     "leaflet-geocoder-mapzen": "^1.7.1",
     "mapzen-scarab": "git+https://github.com/mapzen/scarab.git"
   },

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -24,7 +24,7 @@ describe('Map Control Test', function () {
 
   describe('Leaflet Versions', function () {
     it('check which Leaflet version it is', function () {
-      expect(L.version).to.equal('1.0.1');
+      expect(L.version).to.equal('1.0.2');
     });
   });
 


### PR DESCRIPTION
- closes #315 
- I checked leaflet [v1.0.2 changelog](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md) and our example folders. It seems that it is ok to bump up to 1.0.2. But I will appreciate second eyes! 👀 