### PR TITLE
Add tangramOptions object

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,12 +10,21 @@ mapzen.js is an open-source JavaScript SDK and an extension of [Leaflet](http://
 
 | Option  | Type   | Default   | Description            |
 |---------|--------|-----------|------------------------|
-| `scene` | String | `L.Mapzen.BasemapStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.BasemapStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
+| `apiKey`| String | null | Mapzen API Key to be used for the components attached to the map.|
+| `attribution` | String | `<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors` | Attribution data in a small text box. `Leaflet` attribution is always there; attribution from this option is placed before `Leaflet` attribution.|
+| `debugTangram`| Boolean | `false` | Whether to load the debug (non-minified) version of Tangram or not. <br>**Deprecated; will be removed in v1.0. See [tangramOptions](#tangramoptions) below.** |
 | `fallbackTile` | [L.TileLayer](http://leafletjs.com/reference.html#tilelayer) | `L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {})` | TileLayer to fall back when WebGL is not available. |
-| `attribution` | String | `<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors` | Attribution data  in a small text box.`Leaflet` attribution is always there; attribution from this option is placed before `Leaflet` attribution.|
-| `apiKey`| string | null | Mapzen API Key to be used for the components attached to the map.|
-| `debugTangram`| Boolean | `false` | Whether to load debug (not minified) version of Tangram or not.|
+| `scene` | String | `L.Mapzen.BasemapStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.BasemapStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file<br>**Deprecated; will be removed in v1.0. See [tangramOptions](#tangramoptions) below.** |
+| `tangramOptions`| [tangramOptions](#tangramoptions) |  See below |  See below |
 
+#### tangramOptions
+
+Set of options related to the appearance and behavior of the Tangram layer.  In addition to the options below, `tangramOptions` may also include any of the options available in the [Tangram options object](https://mapzen.com/documentation/tangram/Tangram-Overview/#options-object).
+
+| Option  | Type   | Default   | Description            |
+|---------|--------|-----------|------------------------|
+| `debug` | Boolean | `false` | Whether to load the debug (non-minified) version of Tangram or not.|
+| `scene` | String | `L.Mapzen.BasemapStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.BasemapStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file |
 
 
 ### Events
@@ -38,7 +47,7 @@ map.on('tangramloaded', function (event) {
 
 ### Draw a map with a map component
 
-You can pass one of [Mapzen's default basemaps](https://mapzen.com/documentation/mapzen-js/api-reference/#basemap-styles) for the `scene`, or you can provide the path to your own Tangram scene file.  If there is no scene file declared, mapzen.js will default to [BubbleWrap](https://mapzen.com/products/maps/bubble-wrap/).
+You can pass one of [Mapzen's basemap styles](https://mapzen.com/documentation/mapzen-js/api-reference/#basemap-styles) as the `scene` via `tangramOptions`, or you can provide the path to your own Tangram scene file.  If there is no scene file declared, mapzen.js will default to [BubbleWrap](https://mapzen.com/products/maps/bubble-wrap/).
 
 Example: 
 
@@ -46,8 +55,10 @@ Example:
 var map = L.Mapzen.map('map', {
   center: [40.74429, -73.99035],
   zoom: 15,
-  scene: L.Mapzen.BasemapStyles.Refill
-})
+  tangramOptions: {
+    scene: L.Mapzen.BasemapStyles.Refill
+  }
+});
 ```
 
 The `center` parameter sets the center point of the map (_[latitude, longitude]_), in decimal degrees. The next line sets the `zoom` level, which is like a map scale or resolution. A small zoom level will show a larger area in less detail, and a larger zoom level value depicts smaller area in greater detail.
@@ -93,7 +104,9 @@ Example:
 
 ```javascript
 var map = L.Mapzen.map('map', {
-  scene: L.Mapzen.BasemapStyles.Refill
+  tangramOptions: {
+    scene: L.Mapzen.BasemapStyles.Refill
+  }
 })
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -15,7 +15,7 @@ mapzen.js is an open-source JavaScript SDK and an extension of [Leaflet](http://
 | `debugTangram`| Boolean | `false` | Whether to load the debug (non-minified) version of Tangram or not. <br>**Deprecated; will be removed in v1.0. See [tangramOptions](#tangramoptions) below.** |
 | `fallbackTile` | [L.TileLayer](http://leafletjs.com/reference.html#tilelayer) | `L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {})` | TileLayer to fall back when WebGL is not available. |
 | `scene` | String | `L.Mapzen.BasemapStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.BasemapStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file<br>**Deprecated; will be removed in v1.0. See [tangramOptions](#tangramoptions) below.** |
-| `tangramOptions`| [tangramOptions](#tangramoptions) |  See below |  See below |
+| `tangramOptions`| Object |  See below |  See [tangramOptions](#tangramoptions) below |
 
 #### tangramOptions
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -33,7 +33,9 @@
         lat = 40.70531
       // creates a map with default (bubble-wrap) style
       var map = L.Mapzen.map('map', {
-        debugTangram: true
+        tangramOptions: {
+          debug: true
+        }
       });
 
       map.setView([lat, lon],13);

--- a/examples/standalone-v1.0.html
+++ b/examples/standalone-v1.0.html
@@ -38,7 +38,9 @@
 
       // creates a map with Tron style basemap
       var map = L.Mapzen.map('map',{
-        scene: L.Mapzen.BasemapStyles.Tron
+        tangramOptions: {
+          scene: L.Mapzen.BasemapStyles.Tron
+        }
       });
 
       map.setView([lat, lon],13);

--- a/examples/standalone.html
+++ b/examples/standalone.html
@@ -31,8 +31,10 @@
       var lon = -74.009;
       var lat = 40.70531;
 
-      var map = L.Mapzen.map('map',{
-        scene: L.Mapzen.BasemapStyles.Refill
+      var map = L.Mapzen.map('map', {
+        tangramOptions: {
+          scene: L.Mapzen.BasemapStyles.Refill
+        }
       });
 
       map.setView([lat, lon],13);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-style": "node-sass --output-style compressed -o dist/ src/scss/mapzen.scss; cp -R node_modules/mapzen-scarab/src/images dist/images; cp -r node_modules/leaflet/dist/images/* dist/images/;",
     "build-standalone-style": "node-sass --output-style compressed -o dist/ src/scss/mapzen.standalone.scss; cp -R node_modules/mapzen-scarab/src/images dist/images; cp -r node_modules/leaflet/dist/images/* dist/images/;",
     "build-dev-style": "node-sass --output-style compressed -o dist/ src/scss/mapzen.scss -w; cp -R node_modules/mapzen-scarab/src/images dist/images; cp -r node_modules/leaflet/dist/images/* dist/images/;",
-    "dev": " watchify  ./src/js/mapzen.js -o dist/mapzen.min.js -v;",
+    "dev": " watchify  ./src/js/mapzen.js -o dist/mapzen.js -v;",
     "build-standalone": "browserify -t browserify-shim ./src/js/mapzen.js --standalone Mapzen > dist/mapzen.standalone.js; browserify -t browserify-shim -t uglifyify ./src/js/mapzen.js --standalone  Mapzen | uglifyjs -c > dist/mapzen.standalone.min.js; npm run-script build-standalone-style;",
     "build": "browserify ./src/js/mapzen.js > dist/mapzen.js; browserify -t uglifyify ./src/js/mapzen.js | uglifyjs -c > dist/mapzen.min.js; npm run-script build-style;"
   },

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -16,9 +16,13 @@ var MapControl = L.Map.extend({
     L.Map.prototype.initialize.call(this, element, opts);
 
     if (this.options._useTangram) {
-      this._tangram = L.Mapzen._tangram({
-        debug: this.options.debugTangram
-      });
+
+      // debugTangram is deprecated; remove in v1.0
+      if (this.options.debugTangram) {
+        options.tangramOptions = L.extend({}, options.tangramOptions, {debug: true});
+      }
+
+      this._tangram = L.Mapzen._tangram(options.tangramOptions);
 
       this._tangram.addTo(this);
 

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -5,7 +5,6 @@ var MapControl = L.Map.extend({
   includes: L.Mixin.Events,
   options: {
     attribution: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors',
-    debugTangram: false,
     zoomSnap: 0,
     _useTangram: true
   },
@@ -16,17 +15,18 @@ var MapControl = L.Map.extend({
     L.Map.prototype.initialize.call(this, element, opts);
 
     if (this.options._useTangram) {
+      var tangramOptions = opts.tangramOptions || {};
 
       // debugTangram is deprecated; remove in v1.0
       if (this.options.debugTangram) {
-        options.tangramOptions = L.extend({}, options.tangramOptions, {debug: true});
+        tangramOptions = L.extend({}, tangramOptions, {debug: true});
       }
       // As of v1.0, scene will need to be part of tangramOptions
       if (this.options.scene) {
-        options.tangramOptions = L.extend({}, options.tangramOptions, {scene: this.options.scene});
+        tangramOptions = L.extend({}, tangramOptions, {scene: this.options.scene});
       }
 
-      this._tangram = L.Mapzen._tangram(options.tangramOptions);
+      this._tangram = L.Mapzen._tangram(tangramOptions);
 
       this._tangram.addTo(this);
 

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -21,6 +21,10 @@ var MapControl = L.Map.extend({
       if (this.options.debugTangram) {
         options.tangramOptions = L.extend({}, options.tangramOptions, {debug: true});
       }
+      // As of v1.0, scene will need to be part of tangramOptions
+      if (this.options.scene) {
+        options.tangramOptions = L.extend({}, options.tangramOptions, {scene: this.options.scene});
+      }
 
       this._tangram = L.Mapzen._tangram(options.tangramOptions);
 

--- a/test/examples/all-defaults.html
+++ b/test/examples/all-defaults.html
@@ -33,10 +33,12 @@
 
       // Default map (Bubble Wrap)
       var map = L.Mapzen.map('map', {
-        debugTangram: true
+        tangramOptions: {
+          debug: false
+        }
       });
 
-      map.setView([lat, lon],13);
+      map.setView([lat, lon], 13);
 
       // Add search box
       var geocoder = L.Mapzen.geocoder();

--- a/test/examples/all-defaults.html
+++ b/test/examples/all-defaults.html
@@ -1,5 +1,5 @@
-<!-- This example assumes you have local version of mapzen.js in dist folder -->
-<!-- Please look at BUILD.md to build local version of mapzen.js -->
+<!-- This example assumes you have local version of mapzen.min.js in dist folder -->
+<!-- Please look at BUILD.md to build local version of mapzen.min.js -->
 <!DOCTYPE html>
 <html>
   <head>
@@ -21,7 +21,7 @@
   </head>
   <body>
     <div id="map"></div>
-    <script src="../../dist/mapzen.js"></script>
+    <script src="../../dist/mapzen.min.js"></script>
     <script>
       var start = performance.now();
       console.log('TIMER: starting timer');
@@ -29,13 +29,12 @@
       var lon = -74.009,
           lat = 40.70531;
 
-      // Default map (Bubble Wrap)
       L.Mapzen.apiKey = 'search--NA8UXg';
 
+      // Default map (Bubble Wrap)
       var map = L.Mapzen.map('map', {
         debugTangram: true
       });
-            // Default map (Bubble Wrap)
 
       map.setView([lat, lon],13);
 

--- a/test/examples/all-defaults.html
+++ b/test/examples/all-defaults.html
@@ -21,7 +21,7 @@
   </head>
   <body>
     <div id="map"></div>
-    <script src="../../dist/mapzen.min.js"></script>
+    <script src="../../dist/mapzen.js"></script>
     <script>
       var start = performance.now();
       console.log('TIMER: starting timer');

--- a/test/examples/eraser-map.html
+++ b/test/examples/eraser-map.html
@@ -12,7 +12,7 @@
   <body>
     <div id="map"></div>
     <script src='https://geoiplookup.wikimedia.org/'></script>
-    <script src="../../dist/mapzen.min.js"></script>
+    <script src="../../dist/mapzen.js"></script>
     <script>
 
       // when GeoIP is available, set the map's initial view to detected coords.

--- a/test/examples/house-style-switcher-embed.html
+++ b/test/examples/house-style-switcher-embed.html
@@ -32,7 +32,7 @@
     </ul>
     <div class="demo-control-next"><i class="fa fa-fw fa-angle-right"></i></div>
   </div>
-  <script src="../../dist/mapzen.min.js"></script>
+  <script src="../../dist/mapzen.js"></script>
   <script src='https://mapzen.com/resources/projects/demo-switcher.js'></script>
 
   <script>

--- a/test/examples/isochrone-map.html
+++ b/test/examples/isochrone-map.html
@@ -6,7 +6,7 @@
     <title>Isochrone service demo</title>
     <meta charset="utf-8">
     <link rel="stylesheet" href="../../dist/mapzen.css">
-    <script src="../../dist/mapzen.min.js"></script>
+    <script src="../../dist/mapzen.js"></script>
     <style>
       html,body{margin: 0; padding: 0}
       #map {
@@ -91,8 +91,8 @@
     // To generate your own key, go to https://mapzen.com/developers/
     var geocoder = L.Mapzen.geocoder('mapzen-JA21Wes');
     geocoder.addTo(map);
-  
-    // add lat/lon hash 
+
+    // add lat/lon hash
     L.Mapzen.hash({
       map: map
     });
@@ -119,7 +119,7 @@
         emoji: '🚌'
       }
     };
-  
+
 
     // Custom Leaflet Control - isochrone parameters
     var IsochroneControl = L.Control.extend({
@@ -130,11 +130,11 @@
       onAdd: function (map) {
           var container = L.DomUtil.create('div', 'isochrone-control');
           container.innerHTML = '<div>'
-            + '  <h3>Travel by:</h3>' 
+            + '  <h3>Travel by:</h3>'
             + '  <ul id="travel-modes">'
             + '    <li><input type="radio" name="modes" id="pedestrian" value="pedestrian" /><span class="emoji">' + defaults['pedestrian'].emoji + '</span><span class="label">' + defaults['pedestrian'].label + '</span></li>'
-            + '    <li><input type="radio" name="modes" id="bicycle" value="bicycle" checked="checked" /><span class="emoji">' + defaults['bicycle'].emoji + '</span><span class="label">' + defaults['bicycle'].label + '</span></li>' 
-            + '    <li><input type="radio" name="modes" id="auto" value="auto" /><span class="emoji">' + defaults['auto'].emoji + '</span><span class="label">' + defaults['auto'].label + '</span></li>' 
+            + '    <li><input type="radio" name="modes" id="bicycle" value="bicycle" checked="checked" /><span class="emoji">' + defaults['bicycle'].emoji + '</span><span class="label">' + defaults['bicycle'].label + '</span></li>'
+            + '    <li><input type="radio" name="modes" id="auto" value="auto" /><span class="emoji">' + defaults['auto'].emoji + '</span><span class="label">' + defaults['auto'].label + '</span></li>'
             + '    <li><input type="radio" name="modes" id="multimodal" value="multimodal" /><span class="emoji">' + defaults['multimodal'].emoji + '</span><span class="label">' + defaults['multimodal'].label + '</span></li>'
             + '  </ul><br>'
             + '  <h3>Estimated times:</h3>'
@@ -205,7 +205,7 @@
 
     function reloadEmoji() {
       var emoji = defaults[mode].emoji;
-      
+
       // define GeoJSON point for emoji label
       var emojiJSON = {
         "type": "FeatureCollection",
@@ -247,12 +247,12 @@
         tooltip.addTo(map);
       }
     }
-    
+
     // Add a Tangram event listener
     map.on('tangramloaded', function(e) {
       var tangramLayer = e.tangramLayer;
       scene = tangramLayer.scene;
-      
+
       tangramLayer.setSelectionEvents({
          click: onMapClick,
          hover: onMapHover

--- a/test/examples/isochrone-map.html
+++ b/test/examples/isochrone-map.html
@@ -78,8 +78,10 @@
     var map = L.Mapzen.map('map', {
       center: [lat, lng],
       zoom: 12,
-      debugTangram: true,
-      scene: 'resources/isochrone-map.yaml'
+      tangramOptions: {
+        debug: true,
+        scene: 'resources/isochrone-map.yaml'
+      }
     });
 
     // Move zoom control to the top right corner of the map

--- a/test/examples/standalone-with-Leaflet-v0.7.html
+++ b/test/examples/standalone-with-Leaflet-v0.7.html
@@ -32,8 +32,10 @@
       var lon = -74.009;
 
       var map = L.Mapzen.map('map',{
-        scene: L.Mapzen.BasemapStyles.Refill,
-        debugTangram: true
+        tangramOptions: {
+          scene: L.Mapzen.BasemapStyles.Refill,
+          debug: true
+        }
       });
 
       map.setView([lat, lon],13);

--- a/test/examples/standalone-with-Leaflet-v0.7.html
+++ b/test/examples/standalone-with-Leaflet-v0.7.html
@@ -23,7 +23,7 @@
   <body>
     <div id="map"></div>
     <script src="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.js"></script>
-    <script src="../../dist/mapzen.standalone.min.js"></script>
+    <script src="../../dist/mapzen.standalone.js"></script>
     <script>
       var start = performance.now();
       console.log('TIMER: starting timer');


### PR DESCRIPTION
Adds a `tangramOptions` object to pass along all [Tangram-related options](https://github.com/tangrams/tangram-docs/blob/gh-pages/pages/Tangram-Overview.md#options-object).  This covers both #319 and #260, and follows @hanbyul-here 's suggested syntax for the `tangramOptions` object.

Feedback welcome!  :)

**Still to do:**
- [x] Fix failing tests
- [x] Update documentation
