### PR TITLE
added api key for vector tiles in Tangram

### DIFF
--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -22,6 +22,7 @@ var TangramLayer = L.Class.extend({
     }
     this.hasWebGL = this._hasWebGL();
     this.options = L.extend({}, this.options, opts);
+
     // Start importing script
     // When there is no Tangram object available.
     if (typeof Tangram === 'undefined') {
@@ -53,6 +54,22 @@ var TangramLayer = L.Class.extend({
   },
 
   setUpTangramLayer: function (map) {
+    // If there is no api key in the option object
+    if (!this.options.apiKey) {
+      if (!L.Mapzen.apiKey && !map.apiKey) {
+        console.log('You can only have limited access to Mapzen service withoout api key. Grab your free api key at https://mapzen.com/developers');
+      } else {
+        this.options.apiKey = map.apiKey || L.Mapzen.apiKey;
+      }
+    }
+
+    var sceneFile = this.options.scene;
+
+    this.options.scene = {
+      import: sceneFile,
+      global: { sdk_mapzen_api_key: this.options.apiKey }
+    };
+
     this._layer = Tangram.leafletLayer(this.options).addTo(map);
 
     // Fire 'loaded' event when Tangram layer has been initialized

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -22,7 +22,9 @@ var TangramLayer = L.Class.extend({
     }
     this.hasWebGL = this._hasWebGL();
     this.options = L.extend({}, this.options, opts);
-    this._setUpApiKey();
+
+    this._setUpApiKey(this.options);
+    this._setupSceneObject(this.options);
 
     // Start importing script
     // When there is no Tangram object available.
@@ -55,13 +57,6 @@ var TangramLayer = L.Class.extend({
   },
 
   setUpTangramLayer: function (map) {
-    var sceneFile = this.options.scene;
-
-    this.options.scene = {
-      import: sceneFile,
-      global: { sdk_mapzen_api_key: this.options.apiKey }
-    };
-
     this._layer = Tangram.leafletLayer(this.options).addTo(map);
 
     // Fire 'loaded' event when Tangram layer has been initialized
@@ -83,6 +78,15 @@ var TangramLayer = L.Class.extend({
         console.warn('You can only have limited access to Mapzen Vector tiles withoout api key.');
       }
     }
+  },
+
+  _setupSceneObject: function (opts) {
+    var sceneFile = opts.scene;
+    // Pass emtpy string to as sdk_mapzen_api_key when there is no apiKey
+    this.options.scene = {
+      import: sceneFile,
+      global: { sdk_mapzen_api_key: opts.apiKey || '' }
+    };
   },
 
   _importScript: function (sSrc) {

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -23,8 +23,8 @@ var TangramLayer = L.Class.extend({
     this.hasWebGL = this._hasWebGL();
     this.options = L.extend({}, this.options, opts);
 
-    this._setUpApiKey(this.options);
-    this._setupSceneObject(this.options);
+    this._setUpApiKey();
+    this.options.scene = this._buildSceneObject();
 
     // Start importing script
     // When there is no Tangram object available.
@@ -69,23 +69,21 @@ var TangramLayer = L.Class.extend({
     });
   },
 
-  _setUpApiKey: function (opts) {
-    // If there is no api key in the option object
+  _setUpApiKey: function () {
+    // If there is no api key in the option object, grab the global one.
+    this.options.apiKey = this.options.apiKey || L.Mapzen.apiKey;
+
     if (!this.options.apiKey) {
-      if (L.Mapzen.apiKey) {
-        this.options.apiKey = L.Mapzen.apiKey;
-      } else {
-        console.warn('You can only have limited access to Mapzen Vector tiles withoout api key.');
-      }
+      console.warn('You can only have limited access to Mapzen Vector tiles withoout api key.');
     }
   },
 
-  _setupSceneObject: function (opts) {
-    var sceneFile = opts.scene;
+  _buildSceneObject: function () {
+    var sceneFile = this.options.scene;
     // Pass emtpy string to as sdk_mapzen_api_key when there is no apiKey
-    this.options.scene = {
+    return {
       import: sceneFile,
-      global: { sdk_mapzen_api_key: opts.apiKey || '' }
+      global: { sdk_mapzen_api_key: this.options.apiKey || '' }
     };
   },
 

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -22,6 +22,7 @@ var TangramLayer = L.Class.extend({
     }
     this.hasWebGL = this._hasWebGL();
     this.options = L.extend({}, this.options, opts);
+    this._setUpApiKey();
 
     // Start importing script
     // When there is no Tangram object available.
@@ -54,15 +55,6 @@ var TangramLayer = L.Class.extend({
   },
 
   setUpTangramLayer: function (map) {
-    // If there is no api key in the option object
-    if (!this.options.apiKey) {
-      if (!L.Mapzen.apiKey && !map.apiKey) {
-        console.log('You can only have limited access to Mapzen service withoout api key. Grab your free api key at https://mapzen.com/developers');
-      } else {
-        this.options.apiKey = map.apiKey || L.Mapzen.apiKey;
-      }
-    }
-
     var sceneFile = this.options.scene;
 
     this.options.scene = {
@@ -80,6 +72,17 @@ var TangramLayer = L.Class.extend({
         version: Tangram.version
       });
     });
+  },
+
+  _setUpApiKey: function (opts) {
+    // If there is no api key in the option object
+    if (!this.options.apiKey) {
+      if (L.Mapzen.apiKey) {
+        this.options.apiKey = L.Mapzen.apiKey;
+      } else {
+        console.warn('You can only have limited access to Mapzen Vector tiles withoout api key.');
+      }
+    }
   },
 
   _importScript: function (sSrc) {

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -6,6 +6,7 @@ describe('Map Hash Test', function () {
 
   before(function (done) {
     fakeResult = require('../fixtures/autocomplete.json');
+    L.Mapzen.apiKey = 'search--NA8UXg';
     done();
   })
 
@@ -46,7 +47,7 @@ describe('Map Hash Test', function () {
     });
 
     it('checks that hash for search result is working', function () {
-      var geocoder = L.Mapzen.geocoder('search--NA8UXg');
+      var geocoder = L.Mapzen.geocoder();
       geocoder.addTo(map);
 
       var hash = L.Mapzen.hash({

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -6,7 +6,6 @@ describe('Map Hash Test', function () {
 
   before(function (done) {
     fakeResult = require('../fixtures/autocomplete.json');
-    L.Mapzen.apiKey = 'search--NA8UXg';
     done();
   })
 

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -13,7 +13,6 @@ describe('Map Control Test', function () {
     spy = sinon.spy();
     testMap.addEventListener('tangramloaded', spy);
     testMap.setView([51.505, -0.09], 13);
-    L.Mapzen.apiKey = 'search--NA8UXg';
 
     hasWebGL = L.Mapzen._tangram()._hasWebGL();
 

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -13,6 +13,7 @@ describe('Map Control Test', function () {
     spy = sinon.spy();
     testMap.addEventListener('tangramloaded', spy);
     testMap.setView([51.505, -0.09], 13);
+    L.Mapzen.apiKey = 'search--NA8UXg';
 
     hasWebGL = L.Mapzen._tangram()._hasWebGL();
 


### PR DESCRIPTION
This PR is mainly to share my thoughts about how API key should be handled.

There are 3 ways to pass api key

`L.Mapzen.apiKey = 'apikey'`
`L.Mapzen.map({apiKey: 'apikey'})`
`L.Mapzen.search({apiKey: 'apiKey'})` 

(Currently Search passes the apikey as a first parameter for the instance. => `L.Mapzen.search('apikey', optionObject)` I think it might be better to make apiKey as a property of the option object to promote `L.Mapzen.apiKey` more?  I will make an issue about this) 

All components dealing with apiKey are going to have options to pass apiKey to the component. In this perspective, it will make more sense to pass apiKey to `Basemap` rather than Tagram. The code in this pr was written without consideration for  `Basemap` as a component. 

ex. `L.Mapzen.hash` doesn't  need to have option of apiKey
      `L.Mapzen.routing` is going to have option of apiKey

All components dealing with apikey save the apiKey as an option. It puts priority to 1. the key to pass to the component 2. the key to pass to the map that component is attached to 3. `L.Mapzen.apiKey`. 

Pseudo code showing this priority is  
`this.options.apiKey = this.options.key || this.map.key || L.Mapzen.apiKey`

Since `L.Mapzen.apiKey` is not available until user defines it, apiKey assignment for the component will happen in component's initialization or when the component is attached to the map. 

These are thoughts that I've got while writing this. I think I will remove  parts Tangram accepting apikey if we are moving towards to having `Basemap` as a component, just leave test edits. 

Let me know if anything unclear, or more things to consider.
