### PR TITLE
Add console warning when no API key provided in mapzen.js

### DIFF
--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -6,7 +6,8 @@ var MapControl = L.Map.extend({
   options: {
     attribution: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors',
     zoomSnap: 0,
-    _useTangram: true
+    _useTangram: true,
+    apiKey: null
   },
 
   // overriding Leaflet's map initializer
@@ -49,9 +50,9 @@ var MapControl = L.Map.extend({
   },
 
   _setGlobalApiKey: function (opts) {
-    this.apiKey = opts.apiKey || L.Mapzen.apiKey;
+    this.options.apiKey = opts.apiKey || L.Mapzen.apiKey;
 
-    if (!this.apiKey) {
+    if (!this.options.apiKey) {
 
       console.warn( '****************************** \n'
                   + '***   API key is missing   *** \n'
@@ -62,7 +63,7 @@ var MapControl = L.Map.extend({
     }
 
     // Update global (to be used by other services as needed)
-    L.Mapzen.apiKey = this.apiKey;
+    L.Mapzen.apiKey = this.options.apiKey;
   },
 
   _checkConditions: function (force) {

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -14,6 +14,8 @@ var MapControl = L.Map.extend({
     var opts = L.extend({}, L.Map.prototype.options, options);
     L.Map.prototype.initialize.call(this, element, opts);
 
+    this._setGlobalApiKey(opts);
+
     if (this.options._useTangram) {
       var tangramOptions = opts.tangramOptions || {};
 
@@ -41,22 +43,26 @@ var MapControl = L.Map.extend({
       });
     }
 
-    this._setupConfig(opts);
     this._setDefaultUIPositions();
     this._addAttribution();
     this._checkConditions(false);
   },
 
-  _setupConfig: function (opts) {
-    // If the key is passed through map initialization
-    if (opts.apiKey) {
-      this.apiKey = opts.apiKey;
-      // When there is no L.Mapzen.apiKey yet, map one takes over.
-      if (!L.Mapzen.apiKey) L.Mapzen.apiKey = opts.apiKey;
-    // If the key is not passed through the map, but when there is a global one.
-    } else if (L.Mapzen.apiKey) {
-      this.apiKey = L.Mapzen.apiKey;
+  _setGlobalApiKey: function (opts) {
+    this.apiKey = opts.apiKey || L.Mapzen.apiKey;
+
+    if (!this.apiKey) {
+
+      console.warn( '****************************** \n'
+                  + '***   API key is missing   *** \n'
+                  + '****************************** \n'
+                  + 'Generate your free API key at \n'
+                  + 'https://mapzen.com/developers \n'
+                  + '******************************');
     }
+
+    // Update global (to be used by other services as needed)
+    L.Mapzen.apiKey = this.apiKey;
   },
 
   _checkConditions: function (force) {

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -74,16 +74,19 @@ var TangramLayer = L.Class.extend({
     this.options.apiKey = this.options.apiKey || L.Mapzen.apiKey;
 
     if (!this.options.apiKey) {
-      console.warn('You can only have limited access to Mapzen Vector tiles withoout api key.');
+      console.warn('Without an API key, your access to Mapzen Vector Tiles will be limited.');
     }
   },
 
   _buildSceneObject: function () {
     var sceneFile = this.options.scene;
+
     // Pass emtpy string to as sdk_mapzen_api_key when there is no apiKey
     return {
       import: sceneFile,
-      global: { sdk_mapzen_api_key: this.options.apiKey || '' }
+      global: {
+        sdk_mapzen_api_key: this.options.apiKey || ''
+      }
     };
   },
 
@@ -98,10 +101,12 @@ var TangramLayer = L.Class.extend({
     else document.getElementsByTagName('head')[0].appendChild(this.oScript);
     this.oScript.src = sSrc;
   },
+
   _loadError: function (oError) {
     console.log(oError);
     throw new URIError('The script ' + oError.target.src + ' is not accessible.');
   },
+
   _hasWebGL: function () {
     try {
       var canvas = document.createElement('canvas');


### PR DESCRIPTION
- Add console warning when no API key provided in mapzen.js - #331 & #332 
- Use map's `apiKey` as global if global `L.Mapzen.apiKey` not provided - #343 