### PR TITLE
Update map credit

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,7 +21,7 @@ L.Mapzen.apiKey = 'your-api-key';
 | Option  | Type   | Default   | Description            |
 |---------|--------|-----------|------------------------|
 | `apiKey`| String | L.Mapzen.apiKey | Mapzen API Key to be used for the components. |
-| `attribution` | String | `<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors` | Attribution data in a small text box. `Leaflet` attribution is always there; attribution from this option is placed before `Leaflet` attribution.|
+| `attribution` | String | `© <a href="https://www.mapzen.com/rights">Mapzen</a>,  <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>, and <a href="https://www.mapzen.com/rights/#services-and-data-sources">others</a>` | Attribution data in a small text box. `Leaflet` attribution is always there; attribution from this option is placed before `Leaflet` attribution.|
 | `debugTangram`| Boolean | `false` | Whether to load the debug (non-minified) version of Tangram or not. <br>**Deprecated; will be removed in v1.0. See [tangramOptions](#tangramoptions) below.** |
 | `fallbackTile` | [L.TileLayer](http://leafletjs.com/reference.html#tilelayer) | `L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {})` | TileLayer to fall back when WebGL is not available. |
 | `scene` | String | `L.Mapzen.BasemapStyles.BubbleWrap` | Tangram scene URL, included in `L.Mapzen.BasemapStyles` object. <br> `scene` can also be a single-quoted URL that points to any `.yaml` Tangram scene file<br>**Deprecated; will be removed in v1.0. See [tangramOptions](#tangramoptions) below.** |

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -4,7 +4,7 @@ var L = require('leaflet');
 var MapControl = L.Map.extend({
   includes: L.Mixin.Events,
   options: {
-    attribution: '<a href="https://mapzen.com">Mapzen</a> - <a href="https://www.mapzen.com/rights">Attribution</a>, Data ©<a href="https://openstreetmap.org/copyright">OSM</a> contributors',
+    attribution: '© <a href="https://www.mapzen.com/rights">Mapzen</a>,  <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>, and <a href="https://www.mapzen.com/rights/#services-and-data-sources">others</a>',
     zoomSnap: 0,
     _useTangram: true
   },
@@ -104,9 +104,8 @@ var MapControl = L.Map.extend({
   _addAttribution: function () {
     // Adding Mapzen attribution to Leaflet
     if (this.attributionControl) {
-      this.attributionControl.setPrefix('');
       var tempAttr = this.options.attributionText || this.options.attribution;
-      this.attributionControl.addAttribution(tempAttr);
+      this.attributionControl.setPrefix(tempAttr);
       this.attributionControl.addAttribution('<a href="http://leafletjs.com/">Leaflet</a>');
     }
   }


### PR DESCRIPTION
Update map credit to use new attribution - per #303 

I'm also updating the way we add the attribution to `attributionControl`.  By adding the attribution as a prefix, we can leverage the pipe (`|`) to separate it from "Leaflet".  The result looks a lot cleaner IMO:


© <a href="https://www.mapzen.com/rights">Mapzen</a>,  <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>, and <a href="https://www.mapzen.com/rights/#services-and-data-sources">others</a> | <a href="http://leafletjs.com/">Leaflet</a>

Includes related documentation update  :)