### PR TITLE
Update documentation on API key usage

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,12 +4,14 @@ mapzen.js is an open-source JavaScript SDK and an extension of [Leaflet](http://
 
 ## API Key
 
-mapzen.js requires API key for the access for Mapzen services. Mapzen API Key limit is per each service, so most of times you would want to set up API key one time through `L.Mapzen.apiKey`. You can learn more about API keys and rate limits [here](https://mapzen.com/documentation/overview/#rate-limits).
+mapzen.js requires an API key for access to Mapzen services. These services include [Mapzen Search](https://mapzen.com/documentation/search/) and the [vector tile service](https://mapzen.com/documentation/vector-tiles/) used by [Mapzen Basemaps](https://mapzen.com/documentation/cartography/styles/).
+
+While [rate limits](https://mapzen.com/documentation/overview/#rate-limits) apply to each service individually, mapzen.js allows one global key to be set and used by all services. (Don’t worry–sharing the same API key between different services will not affect individual rate limits. They don’t share limits.)  Find out more about [API keys and rate limits](https://mapzen.com/documentation/overview/#rate-limits) or [sign up for your own key now](https://mapzen.com/developers/).
 
 Define your API key before adding other Mapzen components by setting:
 
 ```javascript
-L.Mapzen.apiKey = 'your-api-key';
+L.Mapzen.apiKey = 'your-mapzen-api-key';
 ```
 
 ## Map

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,17 +1,33 @@
 # Add Mapzen Search box to a map
 
-mapzen.js includes options for adding a [Mapzen Search](https://mapzen.com/products/search/) geocoder box to a map. To use this part of mapzen.js, you need to sign up for a [Mapzen Search API key](https://mapzen.com/developers).
+mapzen.js includes options for adding a [Mapzen Search](https://mapzen.com/products/search/) geocoder box to a map.
 
 Example: 
 
 ```javascript
-var geocoder = L.Mapzen.geocoder('mapzen-api-key');
+var geocoder = L.Mapzen.geocoder();
 geocoder.addTo(map);
 ```
 
-In this example, you are passing a single parameter (the API key in single quotes) to the geocoder. The API key is a code that uniquely identifies your developer account without providing a password. Sign up for your own API key at https://mapzen.com/developers.
+## API key
 
-With a key, you have the full [Mapzen Search rate limits](https://mapzen.com/documentation/overview/#rate-limits) available to you. If you do not provide a valid API key, the number of queries you can perform are reduced greatly.
+[Mapzen Search](https://mapzen.com/products/search/) requires an [API key](https://mapzen.com/developers) to work properly. The above example assumes you've set up a [global 'apiKey'](https://mapzen.com/documentation/mapzen-js/api-reference/#api-key) prior to defining the geocoder:
+
+```javascript
+L.Mapzen.apiKey = 'your-mapzen-api-key';
+
+var geocoder = L.Mapzen.geocoder();
+geocoder.addTo(map);
+```
+
+This global key is used for all of Mapzen services. If you'd rather use a separate key for the geocoder component, you can pass a different key when you set up the geocoder:
+
+```javascript
+var geocoder = L.Mapzen.geocoder('your-other-mapzen-api-key');
+geocoder.addTo(map);
+```
+
+[Mapzen Search rate limits](https://mapzen.com/documentation/overview/#rate-limits) apply.
 
 ## Options
 


### PR DESCRIPTION
Removed reference to keyless API access and added clarity into using `L.Mapzen.apiKey` to set the api key for the geocoder.

**Still to do:**
- [x] Update 'your-api-key' (or whatever we finally decide on)