### PR TITLE
handled the case when there is no parameter

### DIFF
--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -52,9 +52,11 @@ var Geocoder = L.Control.extend({
 
     // If the apiKey is omitted entirely and the
     // first parameter is actually the options
-    if (typeof apiKey === 'object' && !!apiKey) {
+    if (typeof apiKey === 'object') {
       options = apiKey;
       if (L.Mapzen.apiKey) this.apiKey = L.Mapzen.apiKey;
+    } else if (!apiKey) {
+        this.apiKey = L.Mapzen.apiKey
     } else {
       // If user specified the key to use
       this.apiKey = apiKey;


### PR DESCRIPTION
- If you check `test/exmaples/all-default.html`, you can see it is throwing 'too many requests' error (because L.Mapzen.apiKey` is not being passed to geocoder properly) . This pr should fix it.