### PR TITLE
Upgraded basemap styles now require Mapzen API key

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -95,24 +95,24 @@ mapzen.js provides a set of constants for easier access to Mapzen's [basemap sty
 
 | Constant              | Value                                                                                        |
 |-----------------------|----------------------------------------------------------------------------------------------|
-| `BubbleWrap`          | `https://mapzen.com/carto/bubble-wrap-style/6/bubble-wrap-style.zip`                         |
-| `BubbleWrapMoreLabels`| `https://mapzen.com/carto/bubble-wrap-style-more-labels/6/bubble-wrap-style-more-labels.zip` |
-| `BubbleWrapNoLabels`  | `https://mapzen.com/carto/bubble-wrap-style-no-labels/6/bubble-wrap-style-no-labels.zip`     |
-| `Cinnabar`            | `https://mapzen.com/carto/cinnabar-style/6/cinnabar-style.zip`                               |
-| `CinnabarMoreLabels`  | `https://mapzen.com/carto/cinnabar-style-more-labels/6/cinnabar-style-more-labels.zip`       |
-| `CinnabarNoLabels`    | `https://mapzen.com/carto/cinnabar-style-no-labels/6/cinnabar-style-no-labels.zip`           |
-| `Refill`              | `https://mapzen.com/carto/refill-style/6/refill-style.zip`                                   |
-| `RefillMoreLabels`    | `https://mapzen.com/carto/refill-style-more-labels/6/refill-style-more-labels.zip`           |
-| `RefillNoLabels`      | `https://mapzen.com/carto/refill-style-no-labels/6/refill-style-no-labels.zip`               |
-| `Zinc`                | `https://mapzen.com/carto/zinc-style/5/zinc-style.zip`                                       |
-| `ZincMoreLabels`      | `https://mapzen.com/carto/zinc-style-more-labels/5/zinc-style-more-labels.zip`               |
-| `ZincNoLabels`        | `https://mapzen.com/carto/zinc-style-no-labels/5/zinc-style-no-labels.zip`                   |
+| `BubbleWrap`          | `https://mapzen.com/carto/bubble-wrap-style/7/bubble-wrap-style.zip`                         |
+| `BubbleWrapMoreLabels`| `https://mapzen.com/carto/bubble-wrap-style-more-labels/7/bubble-wrap-style-more-labels.zip` |
+| `BubbleWrapNoLabels`  | `https://mapzen.com/carto/bubble-wrap-style-no-labels/7/bubble-wrap-style-no-labels.zip`     |
+| `Cinnabar`            | `https://mapzen.com/carto/cinnabar-style/7/cinnabar-style.zip`                               |
+| `CinnabarMoreLabels`  | `https://mapzen.com/carto/cinnabar-style-more-labels/7/cinnabar-style-more-labels.zip`       |
+| `CinnabarNoLabels`    | `https://mapzen.com/carto/cinnabar-style-no-labels/7/cinnabar-style-no-labels.zip`           |
+| `Refill`              | `https://mapzen.com/carto/refill-style/7/refill-style.zip`                                   |
+| `RefillMoreLabels`    | `https://mapzen.com/carto/refill-style-more-labels/7/refill-style-more-labels.zip`           |
+| `RefillNoLabels`      | `https://mapzen.com/carto/refill-style-no-labels/7/refill-style-no-labels.zip`               |
+| `Zinc`                | `https://mapzen.com/carto/zinc-style/6/zinc-style.zip`                                       |
+| `ZincMoreLabels`      | `https://mapzen.com/carto/zinc-style-more-labels/6/zinc-style-more-labels.zip`               |
+| `ZincNoLabels`        | `https://mapzen.com/carto/zinc-style-no-labels/6/zinc-style-no-labels.zip`                   |
 | `Walkabout`           | `https://mapzen.com/carto/walkabout-style/4/walkabout-style.zip`                             |
 | `WalkaboutMoreLabels` | `https://mapzen.com/carto/walkabout-style-more-labels/4/walkabout-style-more-labels.zip`     |
 | `WalkaboutNoLabels`   | `https://mapzen.com/carto/walkabout-style-no-labels/4/walkabout-style-no-labels.zip`         |
-| `Tron`                | `https://mapzen.com/carto/tron-style/3/tron-style.zip`                                       |
-| `TronMoreLabels`      | `https://mapzen.com/carto/tron-style-more-labels/3/tron-style-more-labels.zip`               |
-| `TronNoLabels`        | `https://mapzen.com/carto/tron-style-no-labels/3/tron-style-no-labels.zip`                   |
+| `Tron`                | `https://mapzen.com/carto/tron-style/4/tron-style.zip`                                       |
+| `TronMoreLabels`      | `https://mapzen.com/carto/tron-style-more-labels/4/tron-style-more-labels.zip`               |
+| `TronNoLabels`        | `https://mapzen.com/carto/tron-style-no-labels/4/tron-style-no-labels.zip`                   |
 
 Example:
 

--- a/src/js/components/basemapStyles.js
+++ b/src/js/components/basemapStyles.js
@@ -1,23 +1,23 @@
 // Mapzen House style for Tangram
 var style = {
-  BubbleWrap: 'https://mapzen.com/carto/bubble-wrap-style/6/bubble-wrap-style.zip',
-  BubbleWrapMoreLabels: 'https://mapzen.com/carto/bubble-wrap-style-more-labels/6/bubble-wrap-style-more-labels.zip',
-  BubbleWrapNoLabels: 'https://mapzen.com/carto/bubble-wrap-style-no-labels/6/bubble-wrap-style-no-labels.zip',
-  Cinnabar: 'https://mapzen.com/carto/cinnabar-style/6/cinnabar-style.zip',
-  CinnabarMoreLabels: 'https://mapzen.com/carto/cinnabar-style-more-labels/6/cinnabar-style-more-labels.zip',
-  CinnabarNoLabels: 'https://mapzen.com/carto/cinnabar-style-no-labels/6/cinnabar-style-no-labels.zip',
-  Refill: 'https://mapzen.com/carto/refill-style/6/refill-style.zip',
-  RefillMoreLabels: 'https://mapzen.com/carto/refill-style-more-labels/6/refill-style-more-labels.zip',
-  RefillNoLabels: 'https://mapzen.com/carto/refill-style-no-labels/6/refill-style-no-labels.zip',
-  Zinc: 'https://mapzen.com/carto/zinc-style/5/zinc-style.zip',
-  ZincMoreLabels: 'https://mapzen.com/carto/zinc-style-more-labels/5/zinc-style-more-labels.zip',
-  ZincNoLabels: 'https://mapzen.com/carto/zinc-style-no-labels/5/zinc-style-no-labels.zip',
+  BubbleWrap: 'https://mapzen.com/carto/bubble-wrap-style/7/bubble-wrap-style.zip',
+  BubbleWrapMoreLabels: 'https://mapzen.com/carto/bubble-wrap-style-more-labels/7/bubble-wrap-style-more-labels.zip',
+  BubbleWrapNoLabels: 'https://mapzen.com/carto/bubble-wrap-style-no-labels/7/bubble-wrap-style-no-labels.zip',
+  Cinnabar: 'https://mapzen.com/carto/cinnabar-style/7/cinnabar-style.zip',
+  CinnabarMoreLabels: 'https://mapzen.com/carto/cinnabar-style-more-labels/7/cinnabar-style-more-labels.zip',
+  CinnabarNoLabels: 'https://mapzen.com/carto/cinnabar-style-no-labels/7/cinnabar-style-no-labels.zip',
+  Refill: 'https://mapzen.com/carto/refill-style/7/refill-style.zip',
+  RefillMoreLabels: 'https://mapzen.com/carto/refill-style-more-labels/7/refill-style-more-labels.zip',
+  RefillNoLabels: 'https://mapzen.com/carto/refill-style-no-labels/7/refill-style-no-labels.zip',
+  Zinc: 'https://mapzen.com/carto/zinc-style/6/zinc-style.zip',
+  ZincMoreLabels: 'https://mapzen.com/carto/zinc-style-more-labels/6/zinc-style-more-labels.zip',
+  ZincNoLabels: 'https://mapzen.com/carto/zinc-style-no-labels/6/zinc-style-no-labels.zip',
   Walkabout: 'https://mapzen.com/carto/walkabout-style/4/walkabout-style.zip',
   WalkaboutMoreLabels: 'https://mapzen.com/carto/walkabout-style-more-labels/4/walkabout-style-more-labels.zip',
   WalkaboutNoLabels: 'https://mapzen.com/carto/walkabout-style-no-labels/4/walkabout-style-no-labels.zip',
-  Tron: 'https://mapzen.com/carto/tron-style/3/tron-style.zip',
-  TronMoreLabels: 'https://mapzen.com/carto/tron-style-more-labels/3/tron-style-more-labels.zip',
-  TronNoLabels: 'https://mapzen.com/carto/tron-style-no-labels/3/tron-style-no-labels.zip'
+  Tron: 'https://mapzen.com/carto/tron-style/4/tron-style.zip',
+  TronMoreLabels: 'https://mapzen.com/carto/tron-style-more-labels/4/tron-style-more-labels.zip',
+  TronNoLabels: 'https://mapzen.com/carto/tron-style-no-labels/4/tron-style-no-labels.zip'
 };
 
 module.exports = style;


### PR DESCRIPTION
The versioned basemap assets are live now so this PR can be merged and distributed at your leisure this week.

- [x] Point to new major versions of the remaining 5 styles (times 3 label variants) that no longer ship with a default API key (they now require a Mapzen API key be specified). 
- [x] Update docs to say which major version is now used.

_NOTE: Walkabout was changed in a previous PR in this repo._