### PR TITLE
Allow for six character api keys

### DIFF
--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -108,7 +108,7 @@ var TangramLayer = L.Class.extend({
    * Not _is_ a valid key, just _looks like_ one.
    */
   _isValidMapzenApiKey: function (string) {
-    return (typeof string === 'string' && string.match(/[-a-z]+-[0-9a-zA-Z_-]{7}/));
+    return (typeof string === 'string' && string.match(/^[-a-z]+-[0-9a-zA-Z_-]{5,7}$/));
   },
 
   /**


### PR DESCRIPTION
Our api key checks have been assuming that api keys would end in 7 characters (after the dash), but I was just issued a six-character api key from mapzen.com/developers (`mapzen-qKhY2A`), which resulted in a failing check.

@sleepylemur - can you confirm what an api key should look like?

cc/ @louh because this check came from either Play or Frame.