### PR TITLE
changed test/examples folder to be on Precog

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,8 @@ test:
     - npm test || npm test || npm test
   post:
     - tar -czf dist/docs.tar.gz docs
-    - cp -Lr examples dist $CIRCLE_ARTIFACTS/
-    - echo '<ul><li><a href="examples/index.html">Basic example</a></li><li><a href="examples/standalone.html">Standalone example</a></li><li><a href="examples/standalone-v1.0.html">Standalone + Leaflet 1.0 example</a></li></ul>' > $CIRCLE_ARTIFACTS/index.html
+    - cp -Lr test/examples dist $CIRCLE_ARTIFACTS/
+    - echo '<ul><li><a href="test/examples/all-defaults.html">All defaults</a></li><li><a href="test/examples/standalone-with-Leaflet-v0.7.html">Standalone example</a></li><li><a href="test/examples/isochrone-map.html"> isochrone map </a></li></ul>' > $CIRCLE_ARTIFACTS/all-defaults.html
 
 deployment:
   release:


### PR DESCRIPTION
- It will make more sense to put `test/examples`which use `dist/mapzen.js` to Precog 