### PR TITLE
update API keys, accounts, and replace text editor paragraph with links

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,7 +6,7 @@ mapzen.js is an open-source JavaScript SDK and an extension of [Leaflet](http://
 
 mapzen.js requires an API key for access to Mapzen services. These services include [Mapzen Search](https://mapzen.com/documentation/search/) and the [vector tile service](https://mapzen.com/documentation/vector-tiles/) used by [Mapzen Basemaps](https://mapzen.com/documentation/cartography/styles/).
 
-While [rate limits](https://mapzen.com/documentation/overview/rate-limits) apply to each service individually, mapzen.js allows one global key to be set and used by all services. (Don’t worry–sharing the same API key between different services will not affect individual rate limits. They don’t share limits.) Find out more about how to [get started limits](https://mapzen.com/documentation/overview/) or [sign up for your own key now](https://mapzen.com/developers/).
+While [rate limits](https://mapzen.com/documentation/overview/rate-limits) apply to each service individually, mapzen.js allows one global key to be set and used by all services. (Don’t worry–sharing the same API key between different services will not affect individual rate limits. They don’t share limits.) Find out more about how to [get started](https://mapzen.com/documentation/overview/) or [sign up for your own key now](https://mapzen.com/developers/).
 
 Define your API key before adding other Mapzen components by setting:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,7 +6,7 @@ mapzen.js is an open-source JavaScript SDK and an extension of [Leaflet](http://
 
 mapzen.js requires an API key for access to Mapzen services. These services include [Mapzen Search](https://mapzen.com/documentation/search/) and the [vector tile service](https://mapzen.com/documentation/vector-tiles/) used by [Mapzen Basemaps](https://mapzen.com/documentation/cartography/styles/).
 
-While [rate limits](https://mapzen.com/documentation/overview/#rate-limits) apply to each service individually, mapzen.js allows one global key to be set and used by all services. (Don’t worry–sharing the same API key between different services will not affect individual rate limits. They don’t share limits.)  Find out more about [API keys and rate limits](https://mapzen.com/documentation/overview/#rate-limits) or [sign up for your own key now](https://mapzen.com/developers/).
+While [rate limits](https://mapzen.com/documentation/overview/rate-limits) apply to each service individually, mapzen.js allows one global key to be set and used by all services. (Don’t worry–sharing the same API key between different services will not affect individual rate limits. They don’t share limits.) Find out more about how to [get started limits](https://mapzen.com/documentation/overview/) or [sign up for your own key now](https://mapzen.com/developers/).
 
 Define your API key before adding other Mapzen components by setting:
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -53,7 +53,7 @@ In this walkthrough, you will learn how to create a basic web map using mapzen.j
 
 mapzen.js requires an API key for access to Mapzen services. These services include [Mapzen Search](https://mapzen.com/documentation/search/) and the [vector tile service](https://mapzen.com/documentation/vector-tiles/) used by [Mapzen Basemaps](https://mapzen.com/documentation/cartography/styles/).
 
-While [rate limits](https://mapzen.com/documentation/overview/rate-limits) apply to each service individually, mapzen.js allows one global key to be set and used by all services. (Don’t worry–sharing the same API key between different services will not affect individual rate limits. They don’t share limits.) Find out more about how to [get started limits](https://mapzen.com/documentation/overview/) or [sign up for your own key now](https://mapzen.com/developers/).
+While [rate limits](https://mapzen.com/documentation/overview/rate-limits) apply to each service individually, mapzen.js allows one global key to be set and used by all services. (Don’t worry–sharing the same API key between different services will not affect individual rate limits. They don’t share limits.) Find out more about how to [get started](https://mapzen.com/documentation/overview/) or [sign up for your own key now](https://mapzen.com/developers/).
 
 Once you've created an API key, keep the Developer page open because you will need to insert the API key later.
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -53,15 +53,13 @@ In this walkthrough, you will learn how to create a basic web map using mapzen.j
 
 mapzen.js requires an API key for access to Mapzen services. These services include [Mapzen Search](https://mapzen.com/documentation/search/) and the [vector tile service](https://mapzen.com/documentation/vector-tiles/) used by [Mapzen Basemaps](https://mapzen.com/documentation/cartography/styles/).
 
-While [rate limits](https://mapzen.com/documentation/overview/#rate-limits) apply to each service individually, mapzen.js allows one global key to be set and used by all services. (Don’t worry–sharing the same API key between different services will not affect individual rate limits. They don’t share limits.)  Find out more about [API keys and rate limits](https://mapzen.com/documentation/overview/#rate-limits) or [sign up for your own key now](https://mapzen.com/developers/).
+While [rate limits](https://mapzen.com/documentation/overview/rate-limits) apply to each service individually, mapzen.js allows one global key to be set and used by all services. (Don’t worry–sharing the same API key between different services will not affect individual rate limits. They don’t share limits.) Find out more about how to [get started limits](https://mapzen.com/documentation/overview/) or [sign up for your own key now](https://mapzen.com/developers/).
 
-Once you've created an API key, keep the Developer page open because you will need to insert the API key later. 
+Once you've created an API key, keep the Developer page open because you will need to insert the API key later.
 
 ### Create an index page
 
-To get started making your map, you will need to use a text editor to update the HTML.
-
-Suggested text editor applications include [Atom - OS X, Windows, Linux](https://atom.io/); [Notepad++ - Windows](https://notepad-plus-plus.org/); [TextWrangler - OS X](http://www.barebones.com/products/textwrangler/); and  [Sublime - OS X, Windows, Linux; free trial](http://www.sublimetext.com/). While you can use the apps installed with your operating system, such as Notepad or TextEdit, they do not provide the helpful indentations, code coloring and autocomplete, or text alignment options found in the other editors. For TextEdit, you must go to the Format menu and click Make Plain Text to use the plain-text version of the file. Do not use an app that applies rich formatting, such as Word or Wordpad.
+To get started making your map, you will need to use a text editor to update the HTML. See some of Mapzen's [suggested text editors](https://mapzen.com/documentation/guides/install-text-editor/) in the developer guide documentation.
 
 The end of the page has a finished version of the HTML that you can use to check your work or review if you need to troubleshoot an error.
 
@@ -153,7 +151,7 @@ To display a Leaflet map on a page, you need a `<div>` element, which is a conta
     <div id="map"></div>
     ```
 
-3. Directly after the `<div>`, add this JavaScript code within a `<script>` tag to initialize a map. You'll add the API key that you created earlier in this section. 
+3. Directly after the `<div>`, add this JavaScript code within a `<script>` tag to initialize a map. You'll add the API key that you created earlier in this section.
 
     ```html
     <script>


### PR DESCRIPTION
Going through all the docs to replace API keys and rate limits with new links to a central page.

Also saw a paragraph that we can replace with a link to the text editor topic in guides.

see https://github.com/mapzen/documentation/issues/192