### PR TITLE
Fix for #362: Warning when no 'global' obj available in scene config

### DIFF
--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -132,7 +132,7 @@ var TangramLayer = L.Class.extend({
       // Check if the API key is set on the params object
       if (source.url_params && source.url_params.api_key) {
         var apiKey = source.url_params.api_key;
-        var globalApi = scene.config.global.sdk_mapzen_api_key;
+        var globalApi = scene.config.global ? scene.config.global.sdk_mapzen_api_key : '';
         // Check if the global property is valid
         if (apiKey === 'global.sdk_mapzen_api_key' && this._isValidMapzenApiKey(globalApi)) {
           valid = true;


### PR DESCRIPTION
When no `global` is present in `scene.config`, the result is a Tangram exception.  Adding a simple check for `scene.config.global`.  Fix for #362.

@louh - this section was adapted from Tangram Frame's API check so may need to check that this same fix isn't required [here](https://github.com/tangrams/tangram-frame/blob/master/main.js#L373).