### PR TITLE
Moved API key checks to individual components

### DIFF
--- a/src/js/components/apiKeyCheck.js
+++ b/src/js/components/apiKeyCheck.js
@@ -1,0 +1,53 @@
+/**
+ * Mapzen API Key Check
+ */
+
+
+/**
+ * The URL_PATTERN handles the old vector.mapzen.com origin (until it is fully
+ * deprecated) as well as the new v1 tile.mapzen.com endpoint.
+ *
+ * Extensions include both vector and raster tile services.
+ */
+var URL_PATTERN = /((https?:)?\/\/(vector|tile).mapzen.com([a-z]|[A-Z]|[0-9]|\/|\{|\}|\.|\||:)+(topojson|geojson|mvt|png|tif|gz))/;
+
+
+/**
+ * A basic check to see if an API key string looks like a valid key. 
+ * Not *is* a valid key, just *looks like* one.
+ * 
+ * @param {string} apiKey Mapzen API key string
+ */
+var isValidMapzenApiKey = function(apiKey) {
+  return (typeof apiKey === 'string' && apiKey.match(/^[-a-z]+-[0-9a-zA-Z_-]{5,7}$/));
+}
+
+
+var warningCounter = 0;
+
+/**
+ * Throw console warning about missing API key
+ * 
+ * @param {string} component Name of component with missing API key (optional)
+ */
+var throwApiKeyWarning = function (component) {
+  var component = component || 'all Mapzen Services';
+
+  console.warn('A valid API key is required for access to ' + component);
+
+  // Show expanded warning the first time
+  if (warningCounter === 0) {
+    console.warn('****************************** \n' +
+                 'Generate your free API key at  \n' +
+                 'https://mapzen.com/developers  \n' +
+                 '******************************');
+  }
+  warningCounter ++;
+}
+
+module.exports = {
+  URL_PATTERN,
+  isValidMapzenApiKey,
+  throwApiKeyWarning
+}
+

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -52,18 +52,10 @@ var MapControl = L.Map.extend({
   _setGlobalApiKey: function (opts) {
     this.options.apiKey = opts.apiKey || L.Mapzen.apiKey;
 
-    // TODO: move API key checks and warnings into individual components
-    if (!this.options.apiKey) {
-      console.warn('****************************** \n' +
-                   '***   API key is missing   *** \n' +
-                   '****************************** \n' +
-                   'Generate your free API key at  \n' +
-                   'https://mapzen.com/developers  \n' +
-                   '******************************');
-    }
-
     // Update global (to be used by other services as needed)
     L.Mapzen.apiKey = this.options.apiKey;
+
+    // Going forward, all API key checks should be performed on individual components
   },
 
   _checkConditions: function (force) {

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -1,5 +1,5 @@
 var L = require('leaflet');
-
+var APIKeyCheck = require('./apiKeyCheck');
 var Geocoder = require('leaflet-geocoder-mapzen/src/core');
 
 module.exports = Geocoder;
@@ -17,5 +17,10 @@ module.exports.geocoder = function (key, options) {
   } else {
     apiKey = key;
   }
+
+  if (!APIKeyCheck.isValidMapzenApiKey(apiKey)) {
+    APIKeyCheck.throwApiKeyWarning('Search');
+  }
+
   return new Geocoder(apiKey, options);
 };


### PR DESCRIPTION
Moved API key checks to individual components.  This will fix the unnecessary warnings seen in Tangram Frame and in other (limited) cases where `L.Mapzen.apiKey` is not assigned.

Closes #356 