### PR TITLE
Add API key placeholders and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ And add a height and width for the map:
 
 ```html
 <script>
+  // Add a Mapzen API key
+  // To generate your key, go to https://mapzen.com/developers/
+  L.Mapzen.apiKey = 'your-mapzen-api-key';
+
   // Add a map to the 'map' div
   var map = L.Mapzen.map('map');
 
@@ -59,6 +63,9 @@ And add a height and width for the map:
   map.setView([37.7749, -122.4194], 12);
 </script>
 ```
+
+_Tip: Don't forget to generate your API key at https://mapzen.com/developers/_
+
 
 **Done!**
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -21,16 +21,13 @@
     <div id="map"></div>
     <script src="https://mapzen.com/js/mapzen.min.js"></script>
     <script>
+      // Add a Mapzen API key (replace with your own)
+      // To generate your key, go to https://mapzen.com/developers/
+      L.Mapzen.apiKey = 'your-mapzen-api-key';
 
-      var lat, lon;
-       // when GeoIP is available, set the map's initial view to detected coordinates
-      // if (typeof Geo === 'object') {
-      //   lon = Geo.lon
-      //   lat = Geo.lat
-      // } else {
-      // }
-        lon = -74.009,
-        lat = 40.70531
+      var lon = -74.009,
+          lat = 40.70531;
+
       // creates a map with default (bubble-wrap) style
       var map = L.Mapzen.map('map', {
         tangramOptions: {
@@ -44,7 +41,7 @@
       map.zoomControl.setPosition('bottomright');
 
       // adds a search box to a map
-      var geocoder = L.Mapzen.geocoder('search--NA8UXg');
+      var geocoder = L.Mapzen.geocoder();
       geocoder.addTo(map);
 
       // allows for a URL hash to be created

--- a/examples/standalone-v1.0.html
+++ b/examples/standalone-v1.0.html
@@ -24,6 +24,9 @@
     <script src="http://cdn.leafletjs.com/leaflet/v1.0.1/leaflet.js"></script>
     <script src="https://mapzen.com/js/mapzen.standalone.min.js"></script>
     <script>
+      // Add a Mapzen API key (replace with your own)
+      // To generate your key, go to https://mapzen.com/developers/
+      L.Mapzen.apiKey = 'your-mapzen-api-key';
 
       // when GeoIP is available, set the map's initial view to detected coords.
       var lat, lon;

--- a/examples/standalone.html
+++ b/examples/standalone.html
@@ -25,6 +25,9 @@
     <script src='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.standalone.js'></script>
     <script src="https://mapzen.com/js/mapzen.standalone.min.js"></script>
     <script>
+      // Add a Mapzen API key (replace with your own)
+      // To generate your key, go to https://mapzen.com/developers/
+      L.Mapzen.apiKey = 'your-mapzen-api-key';
 
       // when GeoIP is available, set the map's initial view to detected coords.
 


### PR DESCRIPTION
Added placeholders for API keys to README and included examples in `/examples/` directory.

I chose to go with the default `'your-mapzen-api-key'` instead of including working keys in the examples.  This will at least explain to users why the examples don't run out-of-the-box, and where they should go to generate a key.

Closes #369 