### PR TITLE
upgrade Walkabout to v5 (for v2 bike map)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -107,9 +107,9 @@ mapzen.js provides a set of constants for easier access to Mapzen's [basemap sty
 | `Zinc`                | `https://mapzen.com/carto/zinc-style/6/zinc-style.zip`                                       |
 | `ZincMoreLabels`      | `https://mapzen.com/carto/zinc-style-more-labels/6/zinc-style-more-labels.zip`               |
 | `ZincNoLabels`        | `https://mapzen.com/carto/zinc-style-no-labels/6/zinc-style-no-labels.zip`                   |
-| `Walkabout`           | `https://mapzen.com/carto/walkabout-style/4/walkabout-style.zip`                             |
-| `WalkaboutMoreLabels` | `https://mapzen.com/carto/walkabout-style-more-labels/4/walkabout-style-more-labels.zip`     |
-| `WalkaboutNoLabels`   | `https://mapzen.com/carto/walkabout-style-no-labels/4/walkabout-style-no-labels.zip`         |
+| `Walkabout`           | `https://mapzen.com/carto/walkabout-style/5/walkabout-style.zip`                             |
+| `WalkaboutMoreLabels` | `https://mapzen.com/carto/walkabout-style-more-labels/5/walkabout-style-more-labels.zip`     |
+| `WalkaboutNoLabels`   | `https://mapzen.com/carto/walkabout-style-no-labels/5/walkabout-style-no-labels.zip`         |
 | `Tron`                | `https://mapzen.com/carto/tron-style/4/tron-style.zip`                                       |
 | `TronMoreLabels`      | `https://mapzen.com/carto/tron-style-more-labels/4/tron-style-more-labels.zip`               |
 | `TronNoLabels`        | `https://mapzen.com/carto/tron-style-no-labels/4/tron-style-no-labels.zip`                   |

--- a/src/js/components/basemapStyles.js
+++ b/src/js/components/basemapStyles.js
@@ -12,9 +12,9 @@ var style = {
   Zinc: 'https://mapzen.com/carto/zinc-style/6/zinc-style.zip',
   ZincMoreLabels: 'https://mapzen.com/carto/zinc-style-more-labels/6/zinc-style-more-labels.zip',
   ZincNoLabels: 'https://mapzen.com/carto/zinc-style-no-labels/6/zinc-style-no-labels.zip',
-  Walkabout: 'https://mapzen.com/carto/walkabout-style/4/walkabout-style.zip',
-  WalkaboutMoreLabels: 'https://mapzen.com/carto/walkabout-style-more-labels/4/walkabout-style-more-labels.zip',
-  WalkaboutNoLabels: 'https://mapzen.com/carto/walkabout-style-no-labels/4/walkabout-style-no-labels.zip',
+  Walkabout: 'https://mapzen.com/carto/walkabout-style/5/walkabout-style.zip',
+  WalkaboutMoreLabels: 'https://mapzen.com/carto/walkabout-style-more-labels/5/walkabout-style-more-labels.zip',
+  WalkaboutNoLabels: 'https://mapzen.com/carto/walkabout-style-no-labels/5/walkabout-style-no-labels.zip',
   Tron: 'https://mapzen.com/carto/tron-style/4/tron-style.zip',
   TronMoreLabels: 'https://mapzen.com/carto/tron-style-more-labels/4/tron-style-more-labels.zip',
   TronNoLabels: 'https://mapzen.com/carto/tron-style-no-labels/4/tron-style-no-labels.zip'


### PR DESCRIPTION
_Same as to last time: https://github.com/mapzen/mapzen.js/pull/357_

This is **ready to merge**, and should be merged ASAP for bike map v2 blog post going live Thursday, May 11th, 2017.

- [x] Carto S3 bucket went live
- [x] Verified new v5 Walkabout assets in Tangram Play