### PR TITLE
made apikeycheck instance always to return option object  (even if it is empty)

### DIFF
--- a/src/js/components/apiKeyCheck.js
+++ b/src/js/components/apiKeyCheck.js
@@ -1,3 +1,4 @@
+var L = require('leaflet');
 /**
  * Mapzen API Key Check
  */
@@ -35,7 +36,7 @@ var getKeyAndOptions = function (_key, _options) {
     options = _key;
   } else {
     key = _key;
-    options = _options;
+    options = L.extend(options, _options);;
   }
   return {
     key: key,

--- a/src/js/components/apiKeyCheck.js
+++ b/src/js/components/apiKeyCheck.js
@@ -1,4 +1,3 @@
-var L = require('leaflet');
 /**
  * Mapzen API Key Check
  */
@@ -36,7 +35,7 @@ var getKeyAndOptions = function (_key, _options) {
     options = _key;
   } else {
     key = _key;
-    options = L.extend(options, _options);;
+    options = _options || options;
   }
   return {
     key: key,


### PR DESCRIPTION
- There is an attribute issue now that when user passes api  key for geocoder, the geocoder component doesn't get rid of its default attribution. Currently there is a case options becomes `null`.  We want options from params always be an object to make all the checks less tedious. 