### PR TITLE
Add routing to intro section of docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 mapzen.js is an open-source JavaScript SDK and an extension of [Leaflet](http://leafletjs.com/) for making maps for the web and mobile devices. mapzen.js simplifies the process of using Mapzen's maps within Leaflet.
 
-With mapzen.js, you'll have full access to [Leaflet](http://leafletjs.com/), as well as additional tools for working with [Mapzen basemap styles](https://mapzen.com/products/maps/) and building a customizable geocoder with [Mapzen Search](https://mapzen.com/products/search/). 
+With mapzen.js, you'll have full access to [Leaflet](http://leafletjs.com/), as well as additional tools for working with [Mapzen basemap styles](https://mapzen.com/products/maps/), building a customizable geocoder with [Mapzen Search](https://mapzen.com/products/search/), and routing with [Mapzen Turn-by-Turn](https://mapzen.com/products/turn-by-turn/). 


### PR DESCRIPTION
Need to add Turn-by-Turn to the intro landing page of mapzen.js documentation: https://mapzen.com/documentation/mapzen-js/