### PR TITLE
Fix missing require in apiKeyCheck

### DIFF
--- a/src/js/components/apiKeyCheck.js
+++ b/src/js/components/apiKeyCheck.js
@@ -2,6 +2,8 @@
  * Mapzen API Key Check
  */
 
+var L = require('leaflet');
+
 /**
  * The URL_PATTERN handles the old vector.mapzen.com origin (until it is fully
  * deprecated) as well as the new v1 tile.mapzen.com endpoint.
@@ -69,4 +71,3 @@ module.exports = {
   throwApiKeyWarning: throwApiKeyWarning,
   getKeyAndOptions: getKeyAndOptions
 };
-


### PR DESCRIPTION
This falls back to `window.L`, which causes problems if `window.L` is different to `require('leaflet')`.