### PR TITLE
Update link to leaflet docs

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -128,7 +128,7 @@ After adding these, your index.html file should look something like this.
 
 ### Add a map to the page
 
-To display a Leaflet map on a page, you need a `<div>` element, which is a container on the page that groups elements, with an ID value. If you want to know more about initializing a Leaflet map, see the [Leaflet getting started documentation](http://leafletjs.com/examples/quick-start.html).
+To display a Leaflet map on a page, you need a `<div>` element, which is a container on the page that groups elements, with an ID value. If you want to know more about initializing a Leaflet map, see the [Leaflet getting started documentation](http://leafletjs.com/).
 
 1. At the bottom of the `<head>` section, after the references you added in the earlier steps, add a `<style>` tag and the following attributes to set the size of the map on your webpage.
 


### PR DESCRIPTION
via @burritojustice and @trescube

This fixes the problems with redirects to the leaflet documentation. People should be able to find the documentation (and getting started is on the leaflet homepage at the moment anyway).