### PR TITLE
bumping up to leaflet 1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "corslite": "0.0.7",
-    "leaflet": "1.0.2",
+    "leaflet": "1.2.0",
     "leaflet-control-geocoder": "^1.5.4",
     "leaflet-geocoder-mapzen": "^1.9.0",
     "leaflet-routing-machine": "3.2.5",

--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -2,7 +2,10 @@
 var L = require('leaflet');
 
 var MapControl = L.Map.extend({
-  includes: L.Mixin.Events,
+  // L.Evented is present in Leaflet v1+
+  // L.Mixin.Events is legacy; was deprecated in Leaflet v1 and started
+  // logging deprecation warnings in console in v1.1
+  includes: L.Evented ? L.Evented.prototype : L.Mixin.Events,
   options: {
     attribution: '© <a href="https://www.mapzen.com/rights">Mapzen</a>,  <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>, and <a href="https://www.mapzen.com/rights/#services-and-data-sources">others</a>',
     zoomSnap: 0,

--- a/src/js/components/tangram.js
+++ b/src/js/components/tangram.js
@@ -10,7 +10,7 @@ var tangramVersion = '0.13';
 var tangramPath = 'https://mapzen.com/tangram/' + tangramVersion + '/';
 
 var TangramLayer = L.Class.extend({
-  includes: L.Mixin.Events,
+  includes: L.Evented ? L.Evented.prototype : L.Mixin.Events,
   options: {
     fallbackTileURL: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
     tangramURL: tangramPath + 'tangram.min.js',

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -19,7 +19,6 @@ describe('Map Hash Test', function () {
   });
 
   afterEach(function () {
-    map.remove();
     el.parentNode.removeChild(el);
   })
 

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -25,7 +25,7 @@ describe('Map Control Test', function () {
 
   describe('Leaflet Versions', function () {
     it('check which Leaflet version it is', function () {
-      expect(L.version).to.equal('1.0.2');
+      expect(L.version).to.equal('1.2.0');
     });
   });
 


### PR DESCRIPTION
- bumping up to Leaflet 1.2
- used Leaflet Geocoder Mapzen way of selectively including `L.mixin.event` 
- should close #424 