### PR TITLE
skip iframe detection unless it is clearly passed

### DIFF
--- a/src/js/components/mapControl.js
+++ b/src/js/components/mapControl.js
@@ -6,6 +6,7 @@ var MapControl = L.Map.extend({
   options: {
     attribution: '© <a href="https://www.mapzen.com/rights">Mapzen</a>,  <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>, and <a href="https://www.mapzen.com/rights/#services-and-data-sources">others</a>',
     zoomSnap: 0,
+    iframeDetection: false,
     _useTangram: true,
     apiKey: null
   },
@@ -46,7 +47,7 @@ var MapControl = L.Map.extend({
 
     this._setDefaultUIPositions();
     this._addAttribution();
-    this._checkConditions(false);
+    if (this.options.iframeDetection) this._checkConditions(false);
   },
 
   _setGlobalApiKey: function (opts) {

--- a/test/examples/all-defaults.html
+++ b/test/examples/all-defaults.html
@@ -33,6 +33,7 @@
 
       // Default map (Bubble Wrap)
       var map = L.Mapzen.map('map', {
+        iframeDetection: true,
         tangramOptions: {
           debug: false
         }


### PR DESCRIPTION
- We've been disabling `scrollzoom` for iframed map mainly for demos on our homepage. but now mapzen.js gets popular ✨  and being used more than our homepage. This can be unexpected behavior for users especially if they are using some editing tools such as like jsfiddle, codepen.
- We have to add `iframeDetection:true` to our demo maps on homepage. This PR should get merged after those edits.
- closes #420 
- This PR should be merged first https://github.com/mapzen/website/pull/1826