### PR TITLE
Putting geocoder methods back

### DIFF
--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -1,5 +1,57 @@
 var APIKeyCheck = require('./apiKeyCheck');
 var Geocoder = require('leaflet-geocoder-mapzen/src/core');
+var corslite = require('@mapbox/corslite');
+
+Geocoder.prototype.serialize = function (params) {
+  var data = '';
+
+  for (var key in params) {
+    if (params.hasOwnProperty(key)) {
+      var param = params[key];
+      var type = param.toString();
+      var value;
+
+      if (data.length) {
+        data += '&';
+      }
+
+      switch (type) {
+        case '[object Array]':
+          value = (param[0].toString() === '[object Object]') ? JSON.stringify(param) : param.join(',');
+          break;
+        case '[object Object]':
+          value = JSON.stringify(param);
+          break;
+        case '[object Date]':
+          value = param.valueOf();
+          break;
+        default:
+          value = param;
+          break;
+      }
+
+      data += encodeURIComponent(key) + '=' + encodeURIComponent(value);
+    }
+  }
+  return data;
+};
+
+Geocoder.prototype.getSearchResult = function (input, callback) {
+  var param = {
+    text: input
+  };
+  var params = this.getParams(param);
+  corslite(this.options.url + '/search?' + this.serialize(params), callback, true);
+};
+
+Geocoder.prototype.getAutoCompleteResult = function (input, callback) {
+  var param = {
+    text: input
+  };
+
+  var params = this.getParams(param);
+  corslite(this.options.url + '/autocomplete?' + this.serialize(params), callback, true);
+};
 
 module.exports = Geocoder;
 

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -2,40 +2,6 @@ var APIKeyCheck = require('./apiKeyCheck');
 var Geocoder = require('leaflet-geocoder-mapzen/src/core');
 var corslite = require('corslite');
 
-Geocoder.prototype.serialize = function (params) {
-  var data = '';
-
-  for (var key in params) {
-    if (params.hasOwnProperty(key)) {
-      var param = params[key];
-      var type = param.toString();
-      var value;
-
-      if (data.length) {
-        data += '&';
-      }
-
-      switch (type) {
-        case '[object Array]':
-          value = (param[0].toString() === '[object Object]') ? JSON.stringify(param) : param.join(',');
-          break;
-        case '[object Object]':
-          value = JSON.stringify(param);
-          break;
-        case '[object Date]':
-          value = param.valueOf();
-          break;
-        default:
-          value = param;
-          break;
-      }
-
-      data += encodeURIComponent(key) + '=' + encodeURIComponent(value);
-    }
-  }
-  return data;
-};
-
 Geocoder.prototype.getSearchResult = function (input, callback) {
   var param = {
     text: input

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -1,6 +1,6 @@
 var APIKeyCheck = require('./apiKeyCheck');
 var Geocoder = require('leaflet-geocoder-mapzen/src/core');
-var corslite = require('@mapbox/corslite');
+var corslite = require('corslite');
 
 Geocoder.prototype.serialize = function (params) {
   var data = '';

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -10,7 +10,7 @@ Geocoder.prototype.getSearchResult = function (input, callback) {
   corslite(this.options.url + '/search?' + this.serialize(params), callback, true);
 };
 
-Geocoder.prototype.getAutoCompleteResult = function (input, callback) {
+Geocoder.prototype.getAutocompleteResult = function (input, callback) {
   var param = {
     text: input
   };

--- a/test/examples/search-methods-without-ui.html
+++ b/test/examples/search-methods-without-ui.html
@@ -1,0 +1,52 @@
+<!-- This example assumes you have local version of mapzen.min.js in dist folder -->
+<!-- Please look at BUILD.md to build local version of mapzen.min.js -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="../../dist/mapzen.css">
+    <style>
+      html, body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+      #map {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src="../../dist/mapzen.js"></script>
+    <script>
+
+      var lon = -74.009,
+          lat = 40.70531;
+
+      L.Mapzen.apiKey = 'mapzen-6VCZ2xH';
+
+      // Default map (Bubble Wrap)
+      var map = L.Mapzen.map('map', {
+        tangramOptions: {
+          debug: false
+        }
+      });
+
+      map.setView([lat, lon], 13);
+
+      L.Mapzen.hash({map: map});
+      // Add search box
+      var geocoder = L.Mapzen.geocoder();
+
+      geocoder.getSearchResult('Tisch', function(err, resp){
+        console.log(JSON.parse(resp.responseText));
+      })
+
+
+    </script>
+  </body>
+</html>

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -34,19 +34,5 @@ describe('Search Test', function () {
       done();
     });
 
-    it('checks geocoder autocomplete methods without UI exists.', function (done) {
-      var geocoder = L.Mapzen.geocoder();
-      geocoder.getAutocompleteResult('dummy', function (err, resp) {
-        done();
-      });
-    });
-
-    it('checks geocoder search methods without UI exists.', function (done) {
-      var geocoder = L.Mapzen.geocoder();
-      geocoder.getSearchResult('dummy', function (err, resp) {
-        done();
-      });
-    });
-
   })
 });

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -5,7 +5,6 @@ describe('Search Test', function () {
 
   before(function (done) {
     L.Mapzen.apiKey = 'mapzen-cstHyBQ';
-    fakeResult = require('../fixtures/autocomplete.json');
     done();
   })
 

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -1,9 +1,11 @@
 describe('Search Test', function () {
   var el;
   var map;
+  var fakeResult;
 
   before(function (done) {
     L.Mapzen.apiKey = 'mapzen-cstHyBQ';
+    fakeResult = require('../fixtures/autocomplete.json');
     done();
   })
 
@@ -32,5 +34,20 @@ describe('Search Test', function () {
       });
       done();
     });
+
+    it('checks geocoder autocomplete methods without UI exists.', function (done) {
+      var geocoder = L.Mapzen.geocoder();
+      geocoder.getAutocompleteResult('dummy', function (err, resp) {
+        done();
+      });
+    });
+
+    it('checks geocoder search methods without UI exists.', function (done) {
+      var geocoder = L.Mapzen.geocoder();
+      geocoder.getSearchResult('dummy', function (err, resp) {
+        done();
+      });
+    });
+
   })
 });


### PR DESCRIPTION
- I dropped some methods that mapzen.js offered when we change the way of bundling geocoder. Putting those back
- I added the tests just to check there are these methods. (not to make this kind of mistake again) 👈 I took these out since there is a mystery thing going on from Leaflet side breaking tests.