### PR TITLE
clearly bumping up the leaflet geocoder mapzen version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "corslite": "0.0.7",
     "leaflet": "1.2.0",
     "leaflet-control-geocoder": "^1.5.4",
-    "leaflet-geocoder-mapzen": "^1.9.0",
+    "leaflet-geocoder-mapzen": "^1.9.4",
     "leaflet-routing-machine": "3.2.5",
     "leaflet.locatecontrol": "^0.60.0",
     "lrm-mapzen": "^1.3.0",


### PR DESCRIPTION
- [release 0.8.3](https://github.com/mapzen/mapzen.js/releases/tag/release-v0.8.3) didn't include the latest version of Lealfet Geocoder Mapzen. So search methods without UI don't work now :( this should fix
- You can see preview (just console logging) [here](https://precog.mapzen.com/mapzen/mapzen.js/3ecddd6d5781423633072129d8fc2b1f54bdf47d/test/examples/search-methods-without-ui.html#lat=40.7052&lng=-74.0091&z=13)