### PR TITLE
WIP: Update cartography resources for 512px tiles

### DIFF
--- a/src/js/components/basemapStyles.js
+++ b/src/js/components/basemapStyles.js
@@ -1,23 +1,23 @@
 // Mapzen House style for Tangram
 var style = {
-  BubbleWrap: 'https://mapzen.com/carto/bubble-wrap-style/7/bubble-wrap-style.zip',
-  BubbleWrapMoreLabels: 'https://mapzen.com/carto/bubble-wrap-style-more-labels/7/bubble-wrap-style-more-labels.zip',
-  BubbleWrapNoLabels: 'https://mapzen.com/carto/bubble-wrap-style-no-labels/7/bubble-wrap-style-no-labels.zip',
-  Cinnabar: 'https://mapzen.com/carto/cinnabar-style/7/cinnabar-style.zip',
-  CinnabarMoreLabels: 'https://mapzen.com/carto/cinnabar-style-more-labels/7/cinnabar-style-more-labels.zip',
-  CinnabarNoLabels: 'https://mapzen.com/carto/cinnabar-style-no-labels/7/cinnabar-style-no-labels.zip',
-  Refill: 'https://mapzen.com/carto/refill-style/7/refill-style.zip',
-  RefillMoreLabels: 'https://mapzen.com/carto/refill-style-more-labels/7/refill-style-more-labels.zip',
-  RefillNoLabels: 'https://mapzen.com/carto/refill-style-no-labels/7/refill-style-no-labels.zip',
-  Zinc: 'https://mapzen.com/carto/zinc-style/6/zinc-style.zip',
-  ZincMoreLabels: 'https://mapzen.com/carto/zinc-style-more-labels/6/zinc-style-more-labels.zip',
-  ZincNoLabels: 'https://mapzen.com/carto/zinc-style-no-labels/6/zinc-style-no-labels.zip',
-  Walkabout: 'https://mapzen.com/carto/walkabout-style/5/walkabout-style.zip',
-  WalkaboutMoreLabels: 'https://mapzen.com/carto/walkabout-style-more-labels/5/walkabout-style-more-labels.zip',
-  WalkaboutNoLabels: 'https://mapzen.com/carto/walkabout-style-no-labels/5/walkabout-style-no-labels.zip',
-  Tron: 'https://mapzen.com/carto/tron-style/4/tron-style.zip',
-  TronMoreLabels: 'https://mapzen.com/carto/tron-style-more-labels/4/tron-style-more-labels.zip',
-  TronNoLabels: 'https://mapzen.com/carto/tron-style-no-labels/4/tron-style-no-labels.zip'
+  BubbleWrap: 'https://mapzen.com/carto/bubble-wrap-style/8/bubble-wrap-style.zip',
+  BubbleWrapMoreLabels: { 'https://mapzen.com/carto/bubble-wrap-style/8/bubble-wrap-style.zip', 'https://mapzen.com/carto/bubble-wrap-style/8/themes/label-10.zip'} ,
+  BubbleWrapNoLabels: { 'https://mapzen.com/carto/bubble-wrap-style/8/bubble-wrap-style.zip', 'https://mapzen.com/carto/bubble-wrap-style/8/themes/label-0.zip'} ,
+  Cinnabar: 'https://mapzen.com/carto/cinnabar-style/8/cinnabar-style.zip',
+  CinnabarMoreLabels: { 'https://mapzen.com/carto/cinnabar-style/8/cinnabar-style.zip', 'https://mapzen.com/carto/cinnabar-style/8/themes/label-10.zip' },
+  CinnabarNoLabels: { 'https://mapzen.com/carto/cinnabar-style/8/cinnabar-style.zip', 'https://mapzen.com/carto/cinnabar-style/8/themes/label-0.zip' },
+  Refill: 'https://mapzen.com/carto/refill-style/9/refill-style.zip',
+  RefillMoreLabels: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-10.zip' },
+  RefillNoLabels: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-0.zip' },
+  Zinc: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/color-zinc.zip' },
+  ZincMoreLabels: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/color-zinc.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-10.zip' },
+  ZincNoLabels: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/color-zinc.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-0.zip' },
+  Walkabout: 'https://mapzen.com/carto/walkabout-style/6/walkabout-style.zip',
+  WalkaboutMoreLabels: { 'https://mapzen.com/carto/walkabout-style/6/walkabout-style.zip', 'https://mapzen.com/carto/walkabout-style/6/themes/label-10.zip' },
+  WalkaboutNoLabels: { 'https://mapzen.com/carto/walkabout-style/6/walkabout-style.zip', 'https://mapzen.com/carto/walkabout-style/6/themes/label-0.zip' },
+  Tron: 'https://mapzen.com/carto/tron-style/5/tron-style.zip',
+  TronMoreLabels: { 'https://mapzen.com/carto/tron-style/5/tron-style.zip', 'https://mapzen.com/carto/tron-style/5/themes/label-10.zip' },
+  TronNoLabels: { 'https://mapzen.com/carto/tron-style/5/tron-style.zip', 'https://mapzen.com/carto/tron-style/5/themes/label-0.zip' }
 };
 
 module.exports = style;

--- a/src/js/components/basemapStyles.js
+++ b/src/js/components/basemapStyles.js
@@ -2,7 +2,7 @@ var getImportObject = function (sceneArray) {
   return {
     import: sceneArray
   };
-}
+};
 
 // Mapzen House style for Tangram
 var style = {

--- a/src/js/components/basemapStyles.js
+++ b/src/js/components/basemapStyles.js
@@ -1,23 +1,29 @@
+var getImportObject = function (sceneArray) {
+  return {
+    import: sceneArray
+  };
+}
+
 // Mapzen House style for Tangram
 var style = {
   BubbleWrap: 'https://mapzen.com/carto/bubble-wrap-style/8/bubble-wrap-style.zip',
-  BubbleWrapMoreLabels: { 'https://mapzen.com/carto/bubble-wrap-style/8/bubble-wrap-style.zip', 'https://mapzen.com/carto/bubble-wrap-style/8/themes/label-10.zip'} ,
-  BubbleWrapNoLabels: { 'https://mapzen.com/carto/bubble-wrap-style/8/bubble-wrap-style.zip', 'https://mapzen.com/carto/bubble-wrap-style/8/themes/label-0.zip'} ,
+  BubbleWrapMoreLabels: getImportObject(['https://mapzen.com/carto/bubble-wrap-style/8/bubble-wrap-style.zip', 'https://mapzen.com/carto/bubble-wrap-style/8/themes/label-10.zip']),
+  BubbleWrapNoLabels: getImportObject(['https://mapzen.com/carto/bubble-wrap-style/8/bubble-wrap-style.zip', 'https://mapzen.com/carto/bubble-wrap-style/8/themes/label-0.zip']),
   Cinnabar: 'https://mapzen.com/carto/cinnabar-style/8/cinnabar-style.zip',
-  CinnabarMoreLabels: { 'https://mapzen.com/carto/cinnabar-style/8/cinnabar-style.zip', 'https://mapzen.com/carto/cinnabar-style/8/themes/label-10.zip' },
-  CinnabarNoLabels: { 'https://mapzen.com/carto/cinnabar-style/8/cinnabar-style.zip', 'https://mapzen.com/carto/cinnabar-style/8/themes/label-0.zip' },
+  CinnabarMoreLabels: getImportObject(['https://mapzen.com/carto/cinnabar-style/8/cinnabar-style.zip', 'https://mapzen.com/carto/cinnabar-style/8/themes/label-10.zip']),
+  CinnabarNoLabels: getImportObject(['https://mapzen.com/carto/cinnabar-style/8/cinnabar-style.zip', 'https://mapzen.com/carto/cinnabar-style/8/themes/label-0.zip']),
   Refill: 'https://mapzen.com/carto/refill-style/9/refill-style.zip',
-  RefillMoreLabels: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-10.zip' },
-  RefillNoLabels: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-0.zip' },
-  Zinc: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/color-zinc.zip' },
-  ZincMoreLabels: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/color-zinc.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-10.zip' },
-  ZincNoLabels: { 'https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/color-zinc.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-0.zip' },
+  RefillMoreLabels: getImportObject(['https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-10.zip']),
+  RefillNoLabels: getImportObject(['https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-0.zip']),
+  Zinc: getImportObject(['https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/color-zinc.zip']),
+  ZincMoreLabels: getImportObject(['https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/color-zinc.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-10.zip']),
+  ZincNoLabels: getImportObject(['https://mapzen.com/carto/refill-style/9/refill-style.zip', 'https://mapzen.com/carto/refill-style/9/themes/color-zinc.zip', 'https://mapzen.com/carto/refill-style/9/themes/label-0.zip']),
   Walkabout: 'https://mapzen.com/carto/walkabout-style/6/walkabout-style.zip',
-  WalkaboutMoreLabels: { 'https://mapzen.com/carto/walkabout-style/6/walkabout-style.zip', 'https://mapzen.com/carto/walkabout-style/6/themes/label-10.zip' },
-  WalkaboutNoLabels: { 'https://mapzen.com/carto/walkabout-style/6/walkabout-style.zip', 'https://mapzen.com/carto/walkabout-style/6/themes/label-0.zip' },
+  WalkaboutMoreLabels: getImportObject(['https://mapzen.com/carto/walkabout-style/6/walkabout-style.zip', 'https://mapzen.com/carto/walkabout-style/6/themes/label-10.zip']),
+  WalkaboutNoLabels: getImportObject(['https://mapzen.com/carto/walkabout-style/6/walkabout-style.zip', 'https://mapzen.com/carto/walkabout-style/6/themes/label-0.zip']),
   Tron: 'https://mapzen.com/carto/tron-style/5/tron-style.zip',
-  TronMoreLabels: { 'https://mapzen.com/carto/tron-style/5/tron-style.zip', 'https://mapzen.com/carto/tron-style/5/themes/label-10.zip' },
-  TronNoLabels: { 'https://mapzen.com/carto/tron-style/5/tron-style.zip', 'https://mapzen.com/carto/tron-style/5/themes/label-0.zip' }
+  TronMoreLabels: getImportObject(['https://mapzen.com/carto/tron-style/5/tron-style.zip', 'https://mapzen.com/carto/tron-style/5/themes/label-10.zip']),
+  TronNoLabels: getImportObject(['https://mapzen.com/carto/tron-style/5/tron-style.zip', 'https://mapzen.com/carto/tron-style/5/themes/label-0.zip'])
 };
 
 module.exports = style;

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -25,7 +25,43 @@ describe('Map Control Test', function () {
 
   describe('Leaflet Versions', function () {
     it('check which Leaflet version it is', function () {
-      expect(L.version).to.equal('1.2.0');
+      expect(L.version).to.be.above(0.13.1);
+    });
+  });
+
+  describe('Tangram Version', function () {
+    // Mapzen Basemap styles require Tangram version number above
+    it('check Tangram version is above 0.13.1', function () {
+
+      var checkVersionNumber = function(vNum) {
+        var requiredTangramVersionNumber = '0.13.1';
+        var requiredVersionNums = requiredTangramVersionNumber.split('.');
+        var vNums = vNum.split('.');
+
+        if (Number(requiredVersionNums.join()) < Number(vNums.join())) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+
+      var count = 0;
+      var checkTangramVersionNumber = function () {
+        count++;
+        if (hasWebGL) {
+          // Tangram is being loaded asynchronously
+          // Wait Tangram is loaded
+          if (Tangram === undefined && count < 40) {
+            return setTimeout(checkTangramVersionNumber.bind(this), 200);
+          } else if (Tangram) {
+            if (checkVersionNumber(Tangram.version)) done();
+            else done(new Error('Tangram version is not met with required version number.'));
+          } else if (count >= 40) done(new Error('takes too long to load Tangram'))
+        } else {
+          done();
+        }
+      }
+      checkTangramLayer();
     });
   });
 

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -23,15 +23,9 @@ describe('Map Control Test', function () {
     el.parentNode.removeChild(el);
   })
 
-  describe('Leaflet Versions', function () {
-    it('check which Leaflet version it is', function () {
-      expect(L.version).to.be.above(0.13.1);
-    });
-  });
-
   describe('Tangram Version', function () {
     // Mapzen Basemap styles require Tangram version number above
-    it('check Tangram version is above 0.13.1', function () {
+    it('check Tangram version is above 0.13.1', function (done) {
 
       var checkVersionNumber = function(vNum) {
         var requiredTangramVersionNumber = '0.13.1';
@@ -61,7 +55,7 @@ describe('Map Control Test', function () {
           done();
         }
       }
-      checkTangramLayer();
+      checkTangramVersionNumber();
     });
   });
 

--- a/test/spec/mapControl.js
+++ b/test/spec/mapControl.js
@@ -27,12 +27,13 @@ describe('Map Control Test', function () {
     // Mapzen Basemap styles require Tangram version number above
     it('check Tangram version is above 0.13.1', function (done) {
 
+      // House styles requires Tangram > 0.13.1
       var checkVersionNumber = function(vNum) {
         var requiredTangramVersionNumber = '0.13.1';
         var requiredVersionNums = requiredTangramVersionNumber.split('.');
         var vNums = vNum.split('.');
-
-        if (Number(requiredVersionNums.join()) < Number(vNums.join())) {
+        vNums[0] = vNums[0].substring(1);
+        if (Number(vNums[0]) >= Number(requiredVersionNums[0]) && Number(vNums[1]) >= Number(requiredVersionNums[1]) && Number(vNums[2]) >= Number(requiredVersionNums[2])) {
           return true;
         } else {
           return false;
@@ -44,8 +45,8 @@ describe('Map Control Test', function () {
         count++;
         if (hasWebGL) {
           // Tangram is being loaded asynchronously
-          // Wait Tangram is loaded
-          if (Tangram === undefined && count < 40) {
+          // Wait until Tangram is loaded
+          if (!window.Tangram && count < 40) {
             return setTimeout(checkTangramVersionNumber.bind(this), 200);
           } else if (Tangram) {
             if (checkVersionNumber(Tangram.version)) done();


### PR DESCRIPTION
This requires Tangram v0.13.1 or later.

I don't have a clear way to test this, so please advise!

The new recommendation is to import imports of imports. Sometimes the style is just a string URL, authorities it's an object listing multiple imports.

**Zinc** is still included, but should be marked as deprecated for future releases.