### PR TITLE
Updating broken link to scarab

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ mapzen.js includes components from these awesome open-source projects:
 
 - [Leaflet](http://leafletjs.com/)
 - [Leaflet.Locate control](https://github.com/domoritz/leaflet-locatecontrol)
-- [Mapzen Scarab social media control](https://github.com/mapzen/scarab/tree/master/src/components/bug)
+- [Mapzen Scarab social media control](https://github.com/mapzen/scarab)
 - [Mapzen Leaflet geocoder plug-in](https://github.com/mapzen/leaflet-geocoder)
 
 


### PR DESCRIPTION
This readme link was broken, so this PR is sending it to the scarab repo.

Should this link be removed altogether if the scarab repo is deprecated?